### PR TITLE
Adding navigation and profile

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import Onboarding from "./pages/Onboarding.tsx";
 import Catalog from "./pages/Catalog.tsx";
 import Recommendations from "./pages/Recommendations.tsx";
 import Swiping from "./pages/Swiping.tsx";
+import Profile from "./pages/Profile.tsx";
 import NotFound from "./pages/NotFound.tsx";
 import FloatingChat from "./components/FloatingChat.tsx";
 
@@ -65,6 +66,7 @@ const App = () => (
           <Route path="/catalog" element={<RequireAuth><Catalog /></RequireAuth>} />
           <Route path="/recommendations" element={<RequireAuth><Recommendations /></RequireAuth>} />
           <Route path="/swiping" element={<RequireAuth><Swiping /></RequireAuth>} />
+          <Route path="/profile" element={<RequireAuth><Profile /></RequireAuth>} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </BrowserRouter>

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -41,6 +41,7 @@ const Navigation = () => {
           {isLoggedIn &&
             [
               { path: "/catalog", label: "Catalog" },
+              { path: "/profile", label: "Profile" },
               { path: "/recommendations", label: "For You" },
               { path: "/swiping", label: "Swiping" },
             ].map(({ path, label }) => (

--- a/frontend/src/components/OnboardingForm.tsx
+++ b/frontend/src/components/OnboardingForm.tsx
@@ -2,61 +2,17 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { submitOnboarding } from "@/lib/api";
 import { saveOnboardingForCurrentUser } from "@/lib/session";
-import { OnboardingProfile, SkinType, SensitivityLevel, PriceRange, RoutineSize, Category, CATEGORIES, CATEGORY_LABELS } from "@/lib/types";
+import { OnboardingProfile, CATEGORIES, CATEGORY_LABELS } from "@/lib/types";
+import { 
+  SKIN_TYPES, 
+  CONCERNS, 
+  SENSITIVITY_LEVELS, 
+  EXCLUSIONS, 
+  PRICE_RANGES, 
+  ROUTINE_SIZES 
+} from "@/lib/constants";
 import { motion, AnimatePresence } from "framer-motion";
 import { ChevronLeft, ChevronRight, Sparkles } from "lucide-react";
-
-const SKIN_TYPES: { value: SkinType; label: string; emoji: string }[] = [
-  { value: "normal", label: "Normal", emoji: "✨" },
-  { value: "dry", label: "Dry", emoji: "🏜️" },
-  { value: "oily", label: "Oily", emoji: "💧" },
-  { value: "combination", label: "Combination", emoji: "🔄" },
-  { value: "sensitive", label: "Sensitive", emoji: "🌸" },
-  { value: "not_sure", label: "Not Sure", emoji: "🤔" },
-];
-
-const CONCERNS = [
-  { value: "acne", label: "Acne" },
-  { value: "dryness", label: "Dryness" },
-  { value: "oiliness", label: "Oiliness" },
-  { value: "redness", label: "Redness" },
-  { value: "dark_spots", label: "Dark Spots" },
-  { value: "fine_lines", label: "Fine Lines" },
-  { value: "dullness", label: "Dullness" },
-  { value: "large_pores", label: "Large Pores" },
-  { value: "maintenance", label: "Maintenance" },
-];
-
-const SENSITIVITY_LEVELS: { value: SensitivityLevel; label: string }[] = [
-  { value: "very_sensitive", label: "Very Sensitive" },
-  { value: "somewhat_sensitive", label: "Somewhat Sensitive" },
-  { value: "rarely_sensitive", label: "Rarely Sensitive" },
-  { value: "not_sensitive", label: "Not Sensitive" },
-  { value: "not_sure", label: "Not Sure" },
-];
-
-const EXCLUSIONS = [
-  { value: "fragrance", label: "Fragrance" },
-  { value: "alcohol", label: "Alcohol" },
-  { value: "essential_oils", label: "Essential Oils" },
-  { value: "sulfates", label: "Sulfates" },
-  { value: "parabens", label: "Parabens" },
-];
-
-const PRICE_RANGES: { value: PriceRange; label: string; desc: string }[] = [
-  { value: "budget", label: "Budget", desc: "Under $15" },
-  { value: "affordable", label: "Affordable", desc: "$15–$30" },
-  { value: "mid_range", label: "Mid-Range", desc: "$30–$60" },
-  { value: "premium", label: "Premium", desc: "$60+" },
-  { value: "no_preference", label: "No Preference", desc: "Any price" },
-];
-
-const ROUTINE_SIZES: { value: RoutineSize; label: string; desc: string }[] = [
-  { value: "minimal", label: "Minimal", desc: "1–2 products" },
-  { value: "basic", label: "Basic", desc: "3–4 products" },
-  { value: "moderate", label: "Moderate", desc: "5–6 products" },
-  { value: "extensive", label: "Extensive", desc: "7+ products" },
-];
 
 const TOTAL_STEPS = 7;
 

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,0 +1,53 @@
+import { SkinType, SensitivityLevel, PriceRange, RoutineSize } from "./types";
+
+export const SKIN_TYPES: { value: SkinType; label: string; emoji: string }[] = [
+  { value: "normal", label: "Normal", emoji: "✨" },
+  { value: "dry", label: "Dry", emoji: "🏜️" },
+  { value: "oily", label: "Oily", emoji: "💧" },
+  { value: "combination", label: "Combination", emoji: "🔄" },
+  { value: "sensitive", label: "Sensitive", emoji: "🌸" },
+  { value: "not_sure", label: "Not Sure", emoji: "🤔" },
+];
+
+export const CONCERNS = [
+  { value: "acne", label: "Acne" },
+  { value: "dryness", label: "Dryness" },
+  { value: "oiliness", label: "Oiliness" },
+  { value: "redness", label: "Redness" },
+  { value: "dark_spots", label: "Dark Spots" },
+  { value: "fine_lines", label: "Fine Lines" },
+  { value: "dullness", label: "Dullness" },
+  { value: "large_pores", label: "Large Pores" },
+  { value: "maintenance", label: "Maintenance" },
+];
+
+export const SENSITIVITY_LEVELS: { value: SensitivityLevel; label: string }[] = [
+  { value: "very_sensitive", label: "Very Sensitive" },
+  { value: "somewhat_sensitive", label: "Somewhat Sensitive" },
+  { value: "rarely_sensitive", label: "Rarely Sensitive" },
+  { value: "not_sensitive", label: "Not Sensitive" },
+  { value: "not_sure", label: "Not Sure" },
+];
+
+export const EXCLUSIONS = [
+  { value: "fragrance", label: "Fragrance" },
+  { value: "alcohol", label: "Alcohol" },
+  { value: "essential_oils", label: "Essential Oils" },
+  { value: "sulfates", label: "Sulfates" },
+  { value: "parabens", label: "Parabens" },
+];
+
+export const PRICE_RANGES: { value: PriceRange; label: string; desc: string }[] = [
+  { value: "budget", label: "Budget", desc: "Under $15" },
+  { value: "affordable", label: "Affordable", desc: "$15–$30" },
+  { value: "mid_range", label: "Mid-Range", desc: "$30–$60" },
+  { value: "premium", label: "Premium", desc: "$60+" },
+  { value: "no_preference", label: "No Preference", desc: "Any price" },
+];
+
+export const ROUTINE_SIZES: { value: RoutineSize; label: string; desc: string }[] = [
+  { value: "minimal", label: "Minimal", desc: "1–2 products" },
+  { value: "basic", label: "Basic", desc: "3–4 products" },
+  { value: "moderate", label: "Moderate", desc: "5–6 products" },
+  { value: "extensive", label: "Extensive", desc: "7+ products" },
+];

--- a/frontend/src/lib/wishlist.ts
+++ b/frontend/src/lib/wishlist.ts
@@ -19,6 +19,7 @@ export function toggleWishlist(productId: number): number[] {
   else list.push(productId);
   localStorage.setItem(WISHLIST_KEY, JSON.stringify(list));
   window.dispatchEvent(new Event("storage"));
+  window.dispatchEvent(new CustomEvent("skincares-wishlist-updated"));
   return [...list];
 }
 

--- a/frontend/src/lib/wishlist.ts
+++ b/frontend/src/lib/wishlist.ts
@@ -18,6 +18,7 @@ export function toggleWishlist(productId: number): number[] {
   if (idx > -1) list.splice(idx, 1);
   else list.push(productId);
   localStorage.setItem(WISHLIST_KEY, JSON.stringify(list));
+  window.dispatchEvent(new Event("storage"));
   return [...list];
 }
 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import { motion, AnimatePresence } from "framer-motion";
 import { 
   User, 
@@ -39,6 +40,7 @@ import ProductModal from "@/components/ProductModal";
 import { useToast } from "@/hooks/use-toast";
 
 const Profile = () => {
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<"preferences" | "wishlist">("preferences");
   const [profile, setProfile] = useState<OnboardingProfile | null>(getUserProfile());
   const [wishlistItems, setWishlistItems] = useState<Product[]>([]);
@@ -48,29 +50,41 @@ const Profile = () => {
   const { toast } = useToast();
 
   useEffect(() => {
+    if (!profile) {
+      navigate("/onboarding");
+    }
+  }, [profile, navigate]);
+
+  useEffect(() => {
     if (activeTab === "wishlist") {
       fetchWishlist();
     }
   }, [activeTab]);
 
   useEffect(() => {
-    const handleStorageChange = () => {
+    const handleSync = () => {
       if (activeTab === "wishlist") {
         fetchWishlist();
       }
     };
-    window.addEventListener("storage", handleStorageChange);
-    return () => window.removeEventListener("storage", handleStorageChange);
+    window.addEventListener("storage", handleSync);
+    window.addEventListener("skincares-wishlist-updated", handleSync);
+    return () => {
+      window.removeEventListener("storage", handleSync);
+      window.removeEventListener("skincares-wishlist-updated", handleSync);
+    };
   }, [activeTab]);
 
   const fetchWishlist = async () => {
     const ids = getWishlist();
+    setLoadingWishlist(true);
+    
     if (ids.length === 0) {
       setWishlistItems([]);
+      setLoadingWishlist(false);
       return;
     }
     
-    setLoadingWishlist(true);
     try {
       const products = await Promise.all(
         ids.map((id) => getProductDetail(id).catch(() => null))

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -1,0 +1,395 @@
+import { useState, useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { 
+  User, 
+  Heart, 
+  Settings, 
+  ChevronRight, 
+  Save, 
+  CheckCircle2, 
+  AlertCircle,
+  Loader2
+} from "lucide-react";
+import Navigation from "@/components/Navigation";
+import { getUserProfile, getWishlist } from "@/lib/wishlist";
+import { getProductDetail, submitOnboarding } from "@/lib/api";
+import { saveOnboardingForCurrentUser } from "@/lib/session";
+import { 
+  OnboardingProfile, 
+  Product, 
+  CATEGORIES, 
+  CATEGORY_LABELS,
+  SkinType,
+  Concern,
+  SensitivityLevel,
+  IngredientExclusion,
+  PriceRange,
+  RoutineSize
+} from "@/lib/types";
+import { 
+  SKIN_TYPES, 
+  CONCERNS, 
+  SENSITIVITY_LEVELS, 
+  EXCLUSIONS, 
+  PRICE_RANGES, 
+  ROUTINE_SIZES 
+} from "@/lib/constants";
+import ProductCard from "@/components/ProductCard";
+import ProductModal from "@/components/ProductModal";
+import { useToast } from "@/hooks/use-toast";
+
+const Profile = () => {
+  const [activeTab, setActiveTab] = useState<"preferences" | "wishlist">("preferences");
+  const [profile, setProfile] = useState<OnboardingProfile | null>(getUserProfile());
+  const [wishlistItems, setWishlistItems] = useState<Product[]>([]);
+  const [loadingWishlist, setLoadingWishlist] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
+  const { toast } = useToast();
+
+  useEffect(() => {
+    if (activeTab === "wishlist") {
+      fetchWishlist();
+    }
+  }, [activeTab]);
+
+  useEffect(() => {
+    const handleStorageChange = () => {
+      if (activeTab === "wishlist") {
+        fetchWishlist();
+      }
+    };
+    window.addEventListener("storage", handleStorageChange);
+    return () => window.removeEventListener("storage", handleStorageChange);
+  }, [activeTab]);
+
+  const fetchWishlist = async () => {
+    const ids = getWishlist();
+    if (ids.length === 0) {
+      setWishlistItems([]);
+      return;
+    }
+    
+    setLoadingWishlist(true);
+    try {
+      const products = await Promise.all(
+        ids.map((id) => getProductDetail(id).catch(() => null))
+      );
+      setWishlistItems(products.filter((p): p is Product => p !== null));
+    } catch (error) {
+      console.error("Failed to fetch wishlist items", error);
+    } finally {
+      setLoadingWishlist(false);
+    }
+  };
+
+  const handleUpdateProfile = <K extends keyof OnboardingProfile>(
+    key: K, 
+    val: OnboardingProfile[K]
+  ) => {
+    if (!profile) return;
+    setProfile({ ...profile, [key]: val });
+  };
+
+  const toggleArray = (
+    key: "concerns" | "ingredient_exclusions" | "product_interests", 
+    val: Concern | IngredientExclusion | Category, 
+    max?: number
+  ) => {
+    if (!profile) return;
+    const arr = profile[key] as (Concern | IngredientExclusion | Category)[];
+    if (arr.includes(val)) {
+      handleUpdateProfile(key, arr.filter((v) => v !== val) as any);
+    } else if (!max || arr.length < max) {
+      handleUpdateProfile(key, [...arr, val] as any);
+    }
+  };
+
+  const handleSavePreferences = async () => {
+    if (!profile) return;
+    setSaving(true);
+    try {
+      const res = await submitOnboarding(profile);
+      saveOnboardingForCurrentUser({
+        recommendationUserId: res.user_id,
+        profile,
+      });
+      toast({
+        title: "Preferences saved",
+        description: "Your skincare profile has been updated successfully.",
+      });
+    } catch (error) {
+      toast({
+        variant: "destructive",
+        title: "Error saving preferences",
+        description: "Please try again later.",
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!profile) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-background pb-20">
+      <Navigation />
+      
+      <main className="container mx-auto max-w-4xl px-4 py-8">
+        <header className="mb-8">
+          <h1 className="font-display text-3xl font-bold text-foreground">My Profile</h1>
+          <p className="text-muted-foreground">Manage your preferences and liked products.</p>
+        </header>
+
+        {/* Tabs */}
+        <div className="mb-8 flex gap-2 rounded-2xl bg-muted p-1">
+          <button
+            onClick={() => setActiveTab("preferences")}
+            className={`flex flex-1 items-center justify-center gap-2 rounded-xl py-3 text-sm font-medium transition-all ${
+              activeTab === "preferences"
+                ? "bg-card text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Settings className="h-4 w-4" />
+            Preferences
+          </button>
+          <button
+            onClick={() => setActiveTab("wishlist")}
+            className={`flex flex-1 items-center justify-center gap-2 rounded-xl py-3 text-sm font-medium transition-all ${
+              activeTab === "wishlist"
+                ? "bg-card text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            <Heart className="h-4 w-4" />
+            Liked Products
+          </button>
+        </div>
+
+        <AnimatePresence mode="wait">
+          {activeTab === "preferences" ? (
+            <motion.div
+              key="preferences"
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+              className="space-y-8"
+            >
+              {/* Skin Type */}
+              <section className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+                <h2 className="mb-4 flex items-center gap-2 font-display text-xl font-bold">
+                  <User className="h-5 w-5 text-primary" />
+                  Skin Type
+                </h2>
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+                  {SKIN_TYPES.map((st) => (
+                    <button
+                      key={st.value}
+                      onClick={() => handleUpdateProfile("skin_type", st.value)}
+                      className={`flex flex-col items-center gap-2 rounded-2xl border-2 p-4 transition-all ${
+                        profile.skin_type === st.value
+                          ? "border-primary bg-primary/5 shadow-sm"
+                          : "border-border bg-card hover:border-primary/30"
+                      }`}
+                    >
+                      <span className="text-2xl">{st.emoji}</span>
+                      <span className="text-sm font-medium text-foreground">{st.label}</span>
+                    </button>
+                  ))}
+                </div>
+              </section>
+
+              {/* Concerns */}
+              <section className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+                <h2 className="mb-4 flex items-center gap-2 font-display text-xl font-bold">
+                  <AlertCircle className="h-5 w-5 text-primary" />
+                  Skin Concerns (up to 3)
+                </h2>
+                <div className="flex flex-wrap gap-2">
+                  {CONCERNS.map((c) => (
+                    <button
+                      key={c.value}
+                      onClick={() => toggleArray("concerns", c.value as Concern, 3)}
+                      className={`rounded-xl px-4 py-2.5 text-sm font-medium transition-all ${
+                        profile.concerns.includes(c.value as Concern)
+                          ? "bg-primary text-primary-foreground shadow-sm"
+                          : "border border-border bg-card text-foreground hover:bg-muted"
+                      }`}
+                    >
+                      {c.label}
+                    </button>
+                  ))}
+                </div>
+              </section>
+
+              {/* Sensitivity */}
+              <section className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+                <h2 className="mb-4 font-display text-xl font-bold">Sensitivity Level</h2>
+                <div className="flex flex-col gap-2">
+                  {SENSITIVITY_LEVELS.map((sl) => (
+                    <button
+                      key={sl.value}
+                      onClick={() => handleUpdateProfile("sensitivity_level", sl.value)}
+                      className={`rounded-2xl border-2 px-5 py-4 text-left text-sm font-medium transition-all ${
+                        profile.sensitivity_level === sl.value
+                          ? "border-primary bg-primary/5"
+                          : "border-border bg-card hover:border-primary/30"
+                      }`}
+                    >
+                      {sl.label}
+                    </button>
+                  ))}
+                </div>
+              </section>
+
+              {/* Exclusions */}
+              <section className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+                <h2 className="mb-4 font-display text-xl font-bold">Ingredients to Avoid</h2>
+                <div className="flex flex-wrap gap-2">
+                  {EXCLUSIONS.map((ex) => (
+                    <button
+                      key={ex.value}
+                      onClick={() => toggleArray("ingredient_exclusions", ex.value as IngredientExclusion)}
+                      className={`rounded-xl px-4 py-2.5 text-sm font-medium transition-all ${
+                        profile.ingredient_exclusions.includes(ex.value as IngredientExclusion)
+                          ? "bg-primary text-primary-foreground shadow-sm"
+                          : "border border-border bg-card text-foreground hover:bg-muted"
+                      }`}
+                    >
+                      {ex.label}
+                    </button>
+                  ))}
+                </div>
+              </section>
+
+              {/* Price Range */}
+              <section className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+                <h2 className="mb-4 font-display text-xl font-bold">Price Range</h2>
+                <div className="flex flex-col gap-2">
+                  {PRICE_RANGES.map((pr) => (
+                    <button
+                      key={pr.value}
+                      onClick={() => handleUpdateProfile("price_range", pr.value)}
+                      className={`flex items-center justify-between rounded-2xl border-2 px-5 py-4 transition-all ${
+                        profile.price_range === pr.value
+                          ? "border-primary bg-primary/5"
+                          : "border-border bg-card hover:border-primary/30"
+                      }`}
+                    >
+                      <span className="text-sm font-medium text-foreground">{pr.label}</span>
+                      <span className="text-xs text-muted-foreground">{pr.desc}</span>
+                    </button>
+                  ))}
+                </div>
+              </section>
+
+              {/* Routine Size */}
+              <section className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+                <h2 className="mb-4 font-display text-xl font-bold">Routine Size</h2>
+                <div className="grid grid-cols-2 gap-3">
+                  {ROUTINE_SIZES.map((rs) => (
+                    <button
+                      key={rs.value}
+                      onClick={() => handleUpdateProfile("routine_size", rs.value)}
+                      className={`flex flex-col items-center gap-1 rounded-2xl border-2 p-5 transition-all ${
+                        profile.routine_size === rs.value
+                          ? "border-primary bg-primary/5 shadow-sm"
+                          : "border-border bg-card hover:border-primary/30"
+                      }`}
+                    >
+                      <span className="text-sm font-medium text-foreground">{rs.label}</span>
+                      <span className="text-xs text-muted-foreground">{rs.desc}</span>
+                    </button>
+                  ))}
+                </div>
+              </section>
+
+              {/* Product Interests */}
+              <section className="rounded-3xl border border-border bg-card p-6 shadow-sm">
+                <h2 className="mb-4 font-display text-xl font-bold">Product Interests (up to 3)</h2>
+                <div className="grid grid-cols-2 gap-3">
+                  {CATEGORIES.map((cat) => (
+                    <button
+                      key={cat}
+                      onClick={() => toggleArray("product_interests", cat, 3)}
+                      className={`rounded-2xl border-2 px-4 py-4 text-sm font-medium transition-all ${
+                        profile.product_interests.includes(cat)
+                          ? "border-primary bg-primary/5 shadow-sm"
+                          : "border-border bg-card hover:border-primary/30"
+                      }`}
+                    >
+                      {CATEGORY_LABELS[cat]}
+                    </button>
+                  ))}
+                </div>
+              </section>
+
+              {/* Save Button */}
+              <div className="sticky bottom-6 flex justify-center pt-4">
+                <button
+                  onClick={handleSavePreferences}
+                  disabled={saving}
+                  className="flex items-center gap-2 rounded-2xl bg-primary px-8 py-4 font-display text-lg font-bold text-primary-foreground shadow-lg transition-all hover:scale-105 active:scale-95 disabled:opacity-50"
+                >
+                  {saving ? (
+                    <Loader2 className="h-5 w-5 animate-spin" />
+                  ) : (
+                    <Save className="h-5 w-5" />
+                  )}
+                  {saving ? "Saving..." : "Save Preferences"}
+                </button>
+              </div>
+            </motion.div>
+          ) : (
+            <motion.div
+              key="wishlist"
+              initial={{ opacity: 0, y: 10 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -10 }}
+            >
+              {loadingWishlist ? (
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {[1, 2, 3].map((i) => (
+                    <div key={i} className="h-64 animate-pulse rounded-2xl bg-muted" />
+                  ))}
+                </div>
+              ) : wishlistItems.length > 0 ? (
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {wishlistItems.map((product) => (
+                    <ProductCard
+                      key={product.product_id}
+                      product={product}
+                      onClick={() => setSelectedProduct(product)}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <div className="flex flex-col items-center justify-center py-20 text-center">
+                  <div className="mb-4 flex h-20 w-20 items-center justify-center rounded-full bg-muted">
+                    <Heart className="h-10 w-10 text-muted-foreground/30" />
+                  </div>
+                  <h3 className="text-xl font-bold text-foreground">No liked products yet</h3>
+                  <p className="mt-2 text-muted-foreground">Products you heart will appear here.</p>
+                </div>
+              )}
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </main>
+
+      <ProductModal
+        product={selectedProduct}
+        onClose={() => setSelectedProduct(null)}
+      />
+    </div>
+  );
+};
+
+export default Profile;


### PR DESCRIPTION
This commit/PR completed the following changes:
Profile Page: Created a new Profile.tsx with a tabbed interface for Preferences and Liked Products.
Preferences Management: the user can now view and update their  skin type, concerns, sensitivity level, ingredient exclusions, price range, and routine size. Changes are saved both locally and to the backend to keep your recommendations relevant.
Wishlist Integration: A dedicated tab displays all your hearted products. You can click on any product to see its details, find dupes, or remove it from your wishlist.
Navigation Update: Replaced the dead "Liked" link with a "Profile" link in the Navigation.tsx.
Code Refactoring: Moved onboarding constants to constants.ts to ensure consistency between the onboarding flow and the profile settings.
Real-time Sync: Updated the wishlist logic to ensure the profile view refreshes automatically when products are liked or unliked.