### PR TITLE
feat: category-first subtype detection for more accurate dupe filtering

### DIFF
--- a/skincarelib/models/dupe_finder.py
+++ b/skincarelib/models/dupe_finder.py
@@ -141,15 +141,7 @@ CATEGORY_TO_SUBTYPE = {
     "OIntments":                     "balm",
 }
 
-# Categories too broad to map directly — fall back to keyword matching
-BROAD_CATEGORIES = {
-    "Creams", "Gels", "Skin Care", "Skin Treatments",
-    "Alternative/Natural Skin Care", "Sets & Kits",
-    "Anti-Wrinkle", "Ethnic Soaps",
-}
-
-# Keyword fallback — used only when category is broad or missing.
-# More comprehensive than the original to cover edge cases.
+# Keyword fallback — used when category is missing or not in the mapping.
 PRODUCT_TYPE_PATTERNS = {
     "eye_treatment":  ["eye cream", "eye gel", "eye serum", "eye oil",
                        "eye lift", "eye mask", "eye treatment", "eye complex",
@@ -184,13 +176,12 @@ PRODUCT_TYPE_PATTERNS = {
 def infer_product_subtype(product_name: str, category: str = None):
     """Infer product subtype using category label as primary signal.
 
-    Category-based detection is preferred since it is an explicit label from
-    the dataset rather than a guess from the product name. Keyword matching
-    on the product name is used only when the category is missing, broad,
-    or not in the mapping.
+    Category mapping is always checked first — if the category has an explicit
+    mapping it is used directly. Keyword matching on the product name is only
+    used when the category is missing or not in the mapping.
     """
-    # Primary: use category if it maps directly to a known subtype
-    if category and category not in BROAD_CATEGORIES:
+    # Primary: use category mapping directly
+    if category:
         subtype = CATEGORY_TO_SUBTYPE.get(category)
         if subtype:
             return subtype

--- a/skincarelib/models/dupe_finder.py
+++ b/skincarelib/models/dupe_finder.py
@@ -19,32 +19,186 @@ METADATA_PATH    = ROOT / "data" / "processed" / "products_with_signals.csv"
 FAISS_INDEX_PATH = ROOT / "artifacts" / "faiss.index"
 
 # How many ANN neighbours to fetch from FAISS before price/subtype filtering.
-# Larger = better recall at the cost of more scoring work downstream.
 FAISS_RETRIEVAL_K = 2500  # ~5% of the catalogue
 
 
 # ---------------------------
 # Product subtype detection
 # ---------------------------
+
+# Direct mapping from dataset category labels to internal subtypes.
+# Used as the primary signal — more reliable than keyword matching since
+# it uses the explicit label already assigned to the product.
+CATEGORY_TO_SUBTYPE = {
+    # Eye
+    "Eye Cream, Gel, Oils, & Serum": "eye_treatment",
+    "Eye Masks & Pads":              "eye_treatment",
+    "Eyes":                          "eye_treatment",
+    "Dark Circle Treatments":        "eye_treatment",
+    "Puffiness Treatments":          "eye_treatment",
+    "Eyelid + Lash":                 "eye_treatment",
+    # Lip
+    "Lip Balms, Gels, Moisturizers & Oils": "lip_treatment",
+    "Lip Care":                      "lip_treatment",
+    "Lip Exfoliators + Scrubs":      "lip_treatment",
+    "Lip Mask":                      "lip_treatment",
+    "Lips":                          "lip_treatment",
+    # Hand & foot
+    "Hand":                          "hand_care",
+    "Hand Masks":                    "hand_care",
+    "Moisturizing Gloves":           "hand_care",
+    "Liquid or Cream Hand Soaps":    "hand_soap",
+    "Feet":                          "foot_care",
+    "Foot Mask":                     "foot_care",
+    # Neck
+    "Neck & Décolleté":              "neck_care",
+    # Masks
+    "Facial Masks":                  "mask",
+    "Face":                          "mask",
+    # Exfoliators
+    "Facial Scrubs":                 "exfoliator",
+    "Exfoliators":                   "exfoliator",
+    "Exfoliators & Scrubs":          "exfoliator",
+    "Exfoliators, Polishes, & Scrubs": "exfoliator",
+    "Microdermabrasion":             "exfoliator",
+    "Polishes":                      "exfoliator",
+    "Scrubs":                        "exfoliator",
+    # Peels
+    "Acids & Peels":                 "peel",
+    "Peels":                         "peel",
+    "Glycolic Acid":                 "peel",
+    "Salicylic Acid":                "peel",
+    "Alpha Beta":                    "peel",
+    # Cleansers
+    "Facial Cleansers":              "cleanser",
+    "Facial Cleansing Milks":        "cleanser",
+    "Facial Foaming Cleansers":      "cleanser",
+    "Facial Washes":                 "cleanser",
+    "Foaming Cleansers":             "cleanser",
+    "Cleansers":                     "cleanser",
+    "Pore Cleansing":                "cleanser",
+    "Facial Cleansing Oil":          "cleansing_oil",
+    "Micellar Water":                "micellar",
+    "Facial Wipes":                  "wipes",
+    "Cloths, Towelettes, & Wipes":   "wipes",
+    "Facial Bar Soap":               "soap",
+    "Bar Soaps":                     "soap",
+    "Liquid Cleansers & Soaps":      "soap",
+    # Serums
+    "Serums":                        "serum",
+    "Serum":                         "serum",
+    "Moisturizing Serums":           "serum",
+    "Complexes":                     "serum",
+    "Drops":                         "serum",
+    "Ampoules":                      "serum",
+    # Retinol
+    "Retinol":                       "retinol",
+    # Toners
+    "Toners":                        "toner",
+    "Toners & Astringents":          "toner",
+    "Astringents":                   "toner",
+    "Essence":                       "toner",
+    # Mists
+    "Mists":                         "mist",
+    "Spray Moisturizer":             "mist",
+    "Spray Moisturizers":            "mist",
+    # Oils
+    "Oils":                          "face_oil",
+    # Gels
+    "Facial Gels":                   "gel",
+    # Moisturizers
+    "Emulsions":                     "moisturizer",
+    "Daytime Moisturizers":          "moisturizer",
+    "Nighttime Moisturizers":        "moisturizer",
+    "Moisturizers":                  "moisturizer",
+    "Tinted Moisturizers":           "tinted_moisturizer",
+    "Moisturizers with SPF":         "sunscreen",
+    # Anti-aging
+    "Anti-Aging":                    "anti_aging",
+    "Anti-Aging/Anti-Wrinkle":       "anti_aging",
+    "Anti-Aging/Anti-Wrinkle (RX)":  "anti_aging",
+    "Anti-Wrinkle":                  "anti_aging",
+    "Anti-Wrinkle Treatments":       "anti_aging",
+    "Firming Treatments":            "anti_aging",
+    # Treatments
+    "Dark Spot Corrector & Pigment Corrector": "spot_treatment",
+    "Spot Treatments":               "spot_treatment",
+    "Skin Lightening":               "spot_treatment",
+    "Acne Care (OTC)":               "acne_treatment",
+    "Pore Treatments":               "pore_treatment",
+    "Pore Refining":                 "pore_treatment",
+    "Pore Strips":                   "pore_treatment",
+    "Lash & Brow Growth":            "lash_brow",
+    # Body
+    "Body":                          "body_care",
+    "Lotions":                       "body_care",
+    "Butters":                       "body_care",
+    "Body Wipes":                    "body_care",
+    "Stretch Marks":                 "body_care",
+    "Ethnic Creams, Lotions & Oils": "body_care",
+    "Balms":                         "balm",
+    "Balms, Ointments & Salves":     "balm",
+    "OIntments":                     "balm",
+}
+
+# Categories too broad to map directly — fall back to keyword matching
+BROAD_CATEGORIES = {
+    "Creams", "Gels", "Skin Care", "Skin Treatments",
+    "Alternative/Natural Skin Care", "Sets & Kits",
+    "Anti-Wrinkle", "Ethnic Soaps",
+}
+
+# Keyword fallback — used only when category is broad or missing.
+# More comprehensive than the original to cover edge cases.
 PRODUCT_TYPE_PATTERNS = {
-    "eye_treatment": ["eye"],
-    "lip_treatment": ["lip"],
-    "hand_care": ["hand"],
-    "body_care": ["body"],
-    "cleanser": ["cleanser", "face wash", "wash"],
-    "serum": ["serum", "ampoule"],
-    "sunscreen": ["spf", "sunscreen", "sun screen"],
-    "mask": ["mask"],
-    "toner": ["toner", "essence"],
+    "eye_treatment":  ["eye cream", "eye gel", "eye serum", "eye oil",
+                       "eye lift", "eye mask", "eye treatment", "eye complex",
+                       "eye repair", "dark circle", "depuff", "de-puff",
+                       "under eye", "undereye"],
+    "lip_treatment":  ["lip balm", "lip mask", "lip oil", "lip gloss",
+                       "lip care", "lip serum", "lip butter", "lip treatment"],
+    "hand_care":      ["hand cream", "hand butter", "hand lotion",
+                       "hand mask", "hand treatment"],
+    "foot_care":      ["foot cream", "foot mask", "foot balm", "heel cream"],
+    "neck_care":      ["neck cream", "neck serum", "décolleté", "decolletage"],
+    "body_care":      ["body cream", "body lotion", "body butter",
+                       "body oil", "body wash", "body treatment"],
+    "cleanser":       ["cleanser", "face wash", "cleansing milk",
+                       "micellar", "cleansing water", "cleansing foam"],
+    "serum":          ["serum", "ampoule", "booster", "concentrate"],
+    "sunscreen":      ["spf", "sunscreen", "sun screen", "sun protection"],
+    "mask":           ["sheet mask", "face mask", "facial mask",
+                       "sleeping mask", "overnight mask", "mud mask",
+                       "clay mask", "peel off mask", "masque", "treatment mask"],
+    "toner":          ["toner", "essence", "lotion toner"],
+    "peel":           ["peel", "exfoliant", "aha", "bha", "lactic acid",
+                       "glycolic acid", "salicylic acid"],
+    "retinol":        ["retinol", "retinoid", "retin-a", "tretinoin"],
+    "face_oil":       ["face oil", "facial oil", "dry oil"],
+    "spot_treatment": ["spot treatment", "blemish treatment",
+                       "acne treatment", "dark spot"],
+    "mist":           ["face mist", "facial mist", "setting spray", "toning mist"],
 }
 
 
-def infer_product_subtype(product_name: str):
-    """Infer a more specific product subtype from product name."""
-    name = str(product_name).lower()
+def infer_product_subtype(product_name: str, category: str = None):
+    """Infer product subtype using category label as primary signal.
 
+    Category-based detection is preferred since it is an explicit label from
+    the dataset rather than a guess from the product name. Keyword matching
+    on the product name is used only when the category is missing, broad,
+    or not in the mapping.
+    """
+    # Primary: use category if it maps directly to a known subtype
+    if category and category not in BROAD_CATEGORIES:
+        subtype = CATEGORY_TO_SUBTYPE.get(category)
+        if subtype:
+            return subtype
+
+    # Fallback: keyword match on product name
+    name = str(product_name).lower()
     for subtype, keywords in PRODUCT_TYPE_PATTERNS.items():
-        if any(keyword in name for keyword in keywords):
+        if any(kw in name for kw in keywords):
             return subtype
 
     return None
@@ -156,7 +310,7 @@ def find_dupes(product_id, top_n=5, max_price=None, weights=None, explain=True):
     source_row      = METADATA[METADATA["product_id"] == product_id].iloc[0]
     source_category = source_row["category"]
     source_price    = source_row["price"]
-    source_subtype  = infer_product_subtype(source_row["product_name"])
+    source_subtype  = infer_product_subtype(source_row["product_name"], source_category)
 
     # --- Retrieval: FAISS ANN instead of full dataframe scan ---
     candidate_ids = _faiss_candidates(product_id, k=FAISS_RETRIEVAL_K)
@@ -170,11 +324,14 @@ def find_dupes(product_id, top_n=5, max_price=None, weights=None, explain=True):
         & (candidates["price"] < source_price)
     ]
 
-    # Subtype filter — keyword based
+    # Subtype filter — category-first with keyword fallback
     if source_subtype is not None:
         filtered = candidates[
-            candidates["product_name"].str.lower().apply(
-                lambda name: infer_product_subtype(name) == source_subtype
+            candidates.apply(
+                lambda row: infer_product_subtype(
+                    row["product_name"], row["category"]
+                ) == source_subtype,
+                axis=1,
             )
         ].copy()
 


### PR DESCRIPTION
Merges subtype detection improvements into main.

Replaces the original keyword-only infer_product_subtype with a category-first approach using the dataset's 80+ category labels as the primary signal. Keyword matching is only used as a fallback when the category isn't in the mapping. Also fixes a logic bug where BROAD_CATEGORIES was checked before the mapping, meaning some explicitly mapped categories could fall through to keyword matching incorrectly.