### PR TITLE
Add ANN-based dupe retrieval + batch dupe population + improved explanations

### DIFF
--- a/scripts/populate_dupes.py
+++ b/scripts/populate_dupes.py
@@ -1,0 +1,109 @@
+"""
+populate_dupes.py
+
+Batch job that runs find_dupes() for every product in the catalogue
+and writes the results to the product_dupes table in Supabase.
+
+Usage:
+    python scripts/populate_dupes.py
+
+Environment variables required (.env):
+    SUPABASE_URL
+    SUPABASE_KEY  (service_role key — needed to bypass RLS)
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+
+from dotenv import load_dotenv
+from supabase import create_client
+
+# Make sure skincarelib is importable
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from skincarelib.models.dupe_finder import find_dupes, PRODUCT_INDEX
+
+load_dotenv()
+
+SUPABASE_URL = os.getenv("SUPABASE_URL")
+SUPABASE_KEY = os.getenv("SUPABASE_KEY")
+
+if not SUPABASE_URL or not SUPABASE_KEY:
+    print("ERROR: SUPABASE_URL and SUPABASE_KEY must be set in .env")
+    sys.exit(1)
+
+supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
+
+BATCH_SIZE = 100        # rows per supabase insert
+TOP_N = 3              # dupes per product
+LOG_EVERY = 500         # print progress every N products
+
+
+def run():
+    product_ids = list(PRODUCT_INDEX.keys())
+    total = len(product_ids)
+    print(f"Starting populate_dupes for {total} products...")
+
+    batch = []
+    inserted = 0
+    skipped = 0
+    errors = 0
+
+    for i, product_id in enumerate(product_ids):
+        try:
+            results = find_dupes(product_id, top_n=TOP_N, explain=True)
+
+            for _, row in results.iterrows():
+                batch.append({
+                    "source_product_id": int(product_id),
+                    "dupe_product_id":   int(row["product_id"]),
+                    "dupe_score":        float(row["dupe_score"]),
+                    "cosine_sim":        float(row["cosine_sim"]),
+                    "price_score":       float(row["price_score"]),
+                    "ingredient_group_score": float(row["ingredient_group_score"]),
+                    "explanation":       str(row.get("explanation", "")),
+                })
+
+        except ValueError:
+            skipped += 1
+            continue
+        except Exception as e:
+            errors += 1
+            print(f"  ERROR product_id={product_id}: {e}")
+            continue
+
+        # flush batch
+        if len(batch) >= BATCH_SIZE:
+            _flush(batch)
+            inserted += len(batch)
+            batch = []
+
+        if (i + 1) % LOG_EVERY == 0:
+            print(f"  [{i+1}/{total}] inserted={inserted} skipped={skipped} errors={errors}")
+
+    # flush remaining
+    if batch:
+        _flush(batch)
+        inserted += len(batch)
+
+    print(f"\nDone. inserted={inserted} skipped={skipped} errors={errors}")
+
+
+def _flush(batch: list):
+    """Insert a batch of rows, ignoring duplicates."""
+    try:
+        supabase.table("product_dupes").upsert(
+            batch,
+            on_conflict="source_product_id,dupe_product_id"
+        ).execute()
+    except Exception as e:
+        print(f"  Supabase flush error: {e}")
+
+
+if __name__ == "__main__":
+    start = time.time()
+    run()
+    print(f"Elapsed: {time.time() - start:.1f}s")

--- a/skincarelib/models/dupe_explainer.py
+++ b/skincarelib/models/dupe_explainer.py
@@ -1,59 +1,81 @@
 """Generates plain-English explanations for dupe finder results."""
 
-_COSINE_LABELS = [
-    (0.90, "Excellent ingredient match"),
-    (0.75, "Strong ingredient match"),
-    (0.60, "Good ingredient match"),
-    (0.00, "Moderate ingredient match"),
-]
 
-_SAVINGS_LABELS = [
-    (0.50, "significantly cheaper"),
-    (0.25, "notably cheaper"),
-    (0.10, "slightly cheaper"),
-    (0.00, "marginally cheaper"),
-]
+def explain_dupe(source_row, candidate_row) -> str:
+    """Return a natural-language explanation for a single dupe result.
 
-_IG_LABELS = [
-    (0.80, "Shares nearly all functional ingredient groups."),
-    (0.60, "Shares most functional ingredient groups."),
-    (0.40, "Shares several functional ingredient groups."),
-    (0.20, "Some overlap in functional ingredient groups."),
-    (0.01, "Limited overlap in functional ingredient groups."),
-]
-
-
-def explain_dupe(source_row, candidate_row):
-    """Return a plain-English explanation for a single dupe result.
-
-    Surfaces the two or three most relevant signals: ingredient similarity,
-    price savings, and functional group overlap.
+    Combines ingredient similarity, functional group overlap, and price
+    savings into a single coherent sentence rather than three separate
+    data points. Avoids exposing internal metrics (cosine scores, group
+    counts) that are meaningful to engineers but not to end users.
     """
-    parts = []
-
-    cosine = float(candidate_row.get("cosine_sim", 0.0))
-    parts.append(f"{_label(cosine, _COSINE_LABELS)} (cosine {cosine:.2f}).")
-
+    source_name  = _short_name(source_row)
     source_price = float(source_row.get("price", 0.0))
-    cand_price = float(candidate_row.get("price", 0.0))
+    cand_price   = float(candidate_row.get("price", 0.0))
+    cosine       = float(candidate_row.get("cosine_sim", 0.0))
+    ig_score     = float(candidate_row.get("ingredient_group_score", 0.0))
 
-    if source_price > 0 and (source_price - cand_price) >= 3.00:
-        savings = (source_price - cand_price) / source_price
-        parts.append(
-            f"{_label(savings, _SAVINGS_LABELS).capitalize()} than the original "
-            f"(${cand_price:.2f} vs ${source_price:.2f}, {savings:.0%} savings)."
-        )
+    # --- ingredient similarity phrase ---
+    if cosine >= 0.90:
+        similarity = "nearly identical ingredient profile to"
+    elif cosine >= 0.78:
+        similarity = "very similar ingredients to"
+    elif cosine >= 0.65:
+        similarity = "a closely matched formulation to"
+    else:
+        similarity = "a comparable formulation to"
 
-    ig = float(candidate_row.get("ingredient_group_score", 0.0))
-    ig_sentence = _label(ig, _IG_LABELS, default="")
-    if ig_sentence:
-        parts.append(ig_sentence)
+    # --- functional group phrase ---
+    if ig_score >= 0.80:
+        function_phrase = "covering the same skin concerns"
+    elif ig_score >= 0.60:
+        function_phrase = "targeting most of the same skin concerns"
+    elif ig_score >= 0.40:
+        function_phrase = "addressing several of the same skin concerns"
+    else:
+        function_phrase = "with some overlapping skin benefits"
 
-    return " ".join(parts)
+    # --- price phrase ---
+    price_phrase = ""
+    if source_price > 0 and cand_price > 0 and source_price > cand_price:
+        savings_pct = (source_price - cand_price) / source_price
+        savings_abs = source_price - cand_price
+
+        if savings_pct >= 0.60:
+            price_phrase = (
+                f" — at ${cand_price:.2f} it saves you "
+                f"${savings_abs:.2f} ({savings_pct:.0%} less)"
+            )
+        elif savings_pct >= 0.30:
+            price_phrase = (
+                f" at a significantly lower price "
+                f"(${cand_price:.2f} vs ${source_price:.2f})"
+            )
+        elif savings_pct >= 0.10:
+            price_phrase = (
+                f" for less "
+                f"(${cand_price:.2f} vs ${source_price:.2f})"
+            )
+
+    return (
+        f"Has a {similarity} {source_name}, "
+        f"{function_phrase}{price_phrase}."
+    )
 
 
-def _label(value, thresholds, default=None):
-    for threshold, label in thresholds:
-        if value >= threshold:
-            return label
-    return default if default is not None else thresholds[-1][1]
+def _short_name(row) -> str:
+    """Return a concise product identifier: 'Brand ProductName'."""
+    name  = str(row.get("product_name", row.get("name", "the original"))).strip()
+    brand = str(row.get("brand", "")).strip()
+
+    # strip brand prefix if already present in name
+    if brand and name.lower().startswith(brand.lower()):
+        name = name[len(brand):].strip()
+
+    # trim at first comma to remove size/variant suffixes
+    if "," in name:
+        name = name.split(",")[0].strip()
+
+    if brand:
+        return f"{brand} {name}"
+    return name

--- a/skincarelib/models/dupe_finder.py
+++ b/skincarelib/models/dupe_finder.py
@@ -19,7 +19,7 @@ METADATA_PATH = ROOT / "data" / "processed" / "products_with_signals.csv"
 FAISS_INDEX_PATH = ROOT / "artifacts" / "faiss.index"
 
 # How many ANN neighbours to fetch from FAISS before price/subtype filtering.
-FAISS_RETRIEVAL_K = 2500  # ~5% of the catalogue
+FAISS_RETRIEVAL_K = 1000  # ~2% of the catalogue
 
 
 def _core_artifact_paths() -> tuple[Path, Path, Path]:
@@ -48,11 +48,15 @@ def _ensure_core_artifacts() -> None:
             + ", ".join(str(path) for path in still_missing)
         )
 
-
 def _build_faiss_index(vectors: np.ndarray):
     normalized = vectors.copy().astype(np.float32)
     faiss.normalize_L2(normalized)
-    index = faiss.IndexFlatIP(normalized.shape[1])
+
+    dim = normalized.shape[1]
+    index = faiss.IndexHNSWFlat(dim, 48, faiss.METRIC_INNER_PRODUCT)
+    index.hnsw.efConstruction = 300
+    index.hnsw.efSearch = 256
+
     index.add(normalized)
     return index
 

--- a/skincarelib/models/vectorizer.py
+++ b/skincarelib/models/vectorizer.py
@@ -219,21 +219,20 @@ def build_schema(tfidf_vec, group_names, cat_names):
 
 
 def build_faiss_index(vectors: np.ndarray):
-    """Build a FAISS flat inner-product index over L2-normalised vectors.
-
-    Normalising first means inner product == cosine similarity, so the index
-    returns the same neighbours as a cosine search but scales to much larger
-    catalogues without slowing down.
-    """
+    """Build a FAISS HNSW ANN index over L2-normalised vectors."""
     if faiss is None:
         raise RuntimeError("faiss is not installed")
 
     vectors = vectors.copy().astype(np.float32)
     faiss.normalize_L2(vectors)
     dim = vectors.shape[1]
-    index = faiss.IndexFlatIP(dim)
+    index = faiss.IndexHNSWFlat(dim, 48, faiss.METRIC_INNER_PRODUCT)
+    index.hnsw.efConstruction = 300
+    index.hnsw.efSearch = 256
+
+
     index.add(vectors)
-    print(f"FAISS index built: {index.ntotal} vectors, dim={dim}")
+    print(f"FAISS HNSW index built: {index.ntotal} vectors, dim={dim}")
     return index
 
 
@@ -252,7 +251,8 @@ def save_outputs(X, df, schema, tfidf_vec):
 
     joblib.dump(tfidf_vec, ARTIFACT_DIR / "tfidf.joblib")
 
-    # FAISS index — used in dupe_finder for fast ANN candidate retrieval
+
+    # FAISS HNSW ANN index — used in dupe_finder for approximate candidate retrieval
     if faiss is not None:
         faiss_index = build_faiss_index(dense)
         faiss.write_index(faiss_index, str(ARTIFACT_DIR / "faiss.index"))


### PR DESCRIPTION
This PR improves the dupe finder system by making retrieval faster, improving explanation quality, and adding a batch job to precompute dupes.

### Changes

1. ANN retrieval with FAISS (HNSW)
Replaced brute-force candidate search with FAISS HNSW (previously used IndexFlatIP)
Reduced FAISS_RETRIEVAL_K from 2500 to 1000 to improve retrieval speed

2. Batch dupe population script
Added scripts/populate_dupes.py
Runs the dupe finder across the full catalogue
Writes results to Supabase (product_dupes table)
Uses batching and upsert to handle large inserts

3. Improved explanations
Rewrote explain_dupe to generate more natural language output
Combines ingredient similarity, function overlap, and price into a single sentence
Removes raw metrics (e.g. cosine scores) from user-facing text

### Why this matters
ANN allows the system to scale to ~50k+ products without full scans
Precomputing dupes makes API responses significantly faster
More natural explanations improve usability and readability
Example output:
“This has a very similar ingredient profile to [product], targeting most of the same skin concerns at a lower price.”