### PR TITLE
Implemented collaborative filtering

### DIFF
--- a/deployment/api/app.py
+++ b/deployment/api/app.py
@@ -39,8 +39,13 @@ from skincarelib.ml_system.ml_feedback_model import (
     UserState,
 )
 from skincarelib.ml_system.feedback_update import compute_user_vector_with_decay
+from skincarelib.ml_system.reranker import (
+    build_diverse_candidate_pool,
+    rerank_candidates,
+)
 from skincarelib.ml_system.swipe_session import SwipeSession
 from skincarelib.ml_system.handler import handle_chat
+from skincarelib.models.user_profile import build_user_vector
 
 logger = logging.getLogger(__name__)
 REMOTE_ASSET_MODE = bool(os.getenv("SUPABASE_URL", "").strip())
@@ -493,9 +498,82 @@ def _ensure_product_vectors_shape() -> None:
         PRODUCT_VECTORS = np.random.randn(product_count, vector_dim).astype(np.float32)
 
 
-# User sessions for online learning
+# ── Cold-start candidate pool diversifier ─────────────────────────────────────
+# MiniBatchKMeans clusters the catalog once at startup. At cold-start time,
+# build_diverse_candidate_pool samples proportionally from the closest clusters
+# instead of always pulling the globally-nearest N products (popularity bias).
+_COLD_START_KMEANS = None
+_COLD_START_CLUSTER_TO_IDS: Dict[int, list] = {}
+_COLD_START_N_CLUSTERS = 20
+
+
+def _fit_cold_start_kmeans() -> None:
+    """Fit MiniBatchKMeans on the product vectors at startup.
+
+    Populates _COLD_START_KMEANS and _COLD_START_CLUSTER_TO_IDS.
+    Falls back silently if sklearn is unavailable or vectors are empty.
+    """
+    global _COLD_START_KMEANS, _COLD_START_CLUSTER_TO_IDS
+    try:
+        from sklearn.cluster import MiniBatchKMeans
+
+        kmeans = MiniBatchKMeans(
+            n_clusters=_COLD_START_N_CLUSTERS,
+            random_state=42,
+            n_init=3,
+            batch_size=2048,
+        )
+        labels = kmeans.fit_predict(PRODUCT_VECTORS)
+
+        # Build row-index → product_id lookup (mirrors the order in PRODUCTS)
+        idx_to_id = {i: str(p.product_id) for i, p in enumerate(PRODUCTS.values())}
+
+        cluster_to_ids: Dict[int, list] = {}
+        for vector_idx, cluster_id in enumerate(labels):
+            pid = idx_to_id.get(vector_idx)
+            if pid is not None:
+                cluster_to_ids.setdefault(int(cluster_id), []).append(pid)
+
+        _COLD_START_KMEANS = kmeans
+        _COLD_START_CLUSTER_TO_IDS = cluster_to_ids
+        logger.info(
+            "Cold-start clusterer fit on %d products (%d clusters).",
+            PRODUCT_VECTORS.shape[0],
+            _COLD_START_N_CLUSTERS,
+        )
+    except Exception as exc:
+        logger.warning(
+            "Cold-start clusterer fit failed, will fall back to top-k cosine: %s", exc
+        )
+
+
+_fit_cold_start_kmeans()
+
+# Price range from onboarding → float budget for build_user_vector
+_PRICE_RANGE_TO_BUDGET: Dict[str, Optional[float]] = {
+    "budget": 25.0,
+    "affordable": 50.0,
+    "mid_range": 100.0,
+    "premium": 200.0,
+    "no_preference": None,
+}
+
+
+def _profile_to_explicit_prefs(profile: OnboardingRequest) -> dict:
+    """Convert all onboarding answers into the explicit_prefs dict for build_user_vector."""
+    return {
+        "skin_type": profile.skin_type,
+        "budget": _PRICE_RANGE_TO_BUDGET.get(profile.price_range),
+        "preferred_categories": [str(c) for c in (profile.product_interests or [])],
+        "preferred_ingredients": [],
+        "banned_ingredients": list(profile.ingredient_exclusions or []),
+        "concerns": [str(c) for c in (profile.concerns or [])],
+        "sensitivity_level": profile.sensitivity_level,
+    }
+
+
+# ── User sessions / state ──────────────────────────────────────────────────────
 USER_SESSIONS: Dict[str, SwipeSession] = {}
-# User ML model states for generating recommendations
 USER_STATES: Dict[str, UserState] = {}
 USER_PROFILES: Dict[str, OnboardingRequest] = {}
 USER_FEEDBACK: List[FeedbackRequest] = []
@@ -909,10 +987,13 @@ def _seed_user_model_from_onboarding(
             if vec is not None:
                 user_state.add_disliked(vec)
 
-    print(
-        f"[Onboarding Seeding] user={user_id} skin_type={skin_type} "
-        f"concerns={skin_concerns} suited={len(suited_products)} "
-        f"unseeded by={len(unsuited_products)}"
+    logger.info(
+        "Onboarding seeding: user=%s skin_type=%s concerns=%s suited=%d unseeded=%d",
+        user_id,
+        skin_type,
+        skin_concerns,
+        len(suited_products),
+        len(unsuited_products),
     )
 
 
@@ -1020,7 +1101,7 @@ def get_recommendations(
         USER_PROFILES[user_id] = db_profile
 
     user_state = USER_STATES.get(user_id) or _load_user_state_from_db(db, user_id)
-    candidates = [product for product in PRODUCTS.values()]
+    candidates = list(PRODUCTS.values())
     if category is not None:
         candidates = [product for product in candidates if product.category == category]
 
@@ -1087,7 +1168,58 @@ def get_recommendations(
             )
             scores = [0.5] * len(candidates)
     else:
-        scores = [0.5] * len(candidates)
+        # Cold start — no real interactions yet. Build preference vector from
+        # onboarding answers (skin type, concerns, sensitivity, budget, categories)
+        # then use cluster-sampled candidate pool to avoid popularity bias.
+        profile = USER_PROFILES.get(user_id)
+        try:
+            if profile is not None:
+                explicit_prefs = _profile_to_explicit_prefs(profile)
+                cold_product_index = _build_product_index()
+                user_vec = build_user_vector(
+                    liked_product_ids=[],
+                    explicit_prefs=explicit_prefs,
+                    product_vectors=PRODUCT_VECTORS,
+                    product_index=cold_product_index,
+                )
+                # Build diverse candidate pool (cluster-sampled to avoid popularity bias)
+                if _COLD_START_KMEANS is not None:
+                    pool = build_diverse_candidate_pool(
+                        user_vector=user_vec,
+                        kmeans=_COLD_START_KMEANS,
+                        cluster_to_ids=_COLD_START_CLUSTER_TO_IDS,
+                        product_vectors=PRODUCT_VECTORS,
+                        product_index=cold_product_index,
+                        pool_size=200,
+                    )
+                else:
+                    # Fallback: top-200 by dot product if clusterer unavailable
+                    norms = np.linalg.norm(PRODUCT_VECTORS, axis=1) + 1e-9
+                    sims = PRODUCT_VECTORS @ user_vec / norms
+                    top_idx = np.argpartition(sims, -200)[-200:]
+                    id_map = {
+                        i: str(p.product_id) for i, p in enumerate(PRODUCTS.values())
+                    }
+                    pool = [id_map[i] for i in top_idx if i in id_map]
+
+                ranked_ids = rerank_candidates(
+                    user_vector=user_vec,
+                    candidate_ids=pool,
+                    product_vectors=PRODUCT_VECTORS,
+                    product_index=cold_product_index,
+                    top_n=limit,
+                )
+                id_to_rank = {pid: i for i, pid in enumerate(ranked_ids)}
+                n = max(len(ranked_ids), 1)
+                for product in candidates:
+                    pid = str(product.product_id)
+                    rank = id_to_rank.get(pid)
+                    scores.append(1.0 - rank / n if rank is not None else 0.0)
+            else:
+                scores = [0.5] * len(candidates)
+        except Exception as e:
+            logger.warning("Cold start scoring failed for user_id=%s: %s", user_id, e)
+            scores = [0.5] * len(candidates)
 
     # Sort by score (highest first)
     ranked = sorted(zip(candidates, scores), key=lambda x: x[1], reverse=True)

--- a/deployment/api/app.py
+++ b/deployment/api/app.py
@@ -46,7 +46,6 @@ from skincarelib.ml_system.reranker import (
     rerank_candidates,
 )
 from skincarelib.ml_system.swipe_session import SwipeSession
-from skincarelib.ml_system.handler import handle_chat
 from skincarelib.models.user_profile import build_user_vector
 
 logger = logging.getLogger(__name__)

--- a/deployment/api/auth/models.py
+++ b/deployment/api/auth/models.py
@@ -10,7 +10,12 @@ class User(Base):
 
     __tablename__ = "users"
 
-    id = Column(UUID(as_uuid=False), primary_key=True, default=lambda: str(uuid.uuid4()), index=True)
+    id = Column(
+        UUID(as_uuid=False),
+        primary_key=True,
+        default=lambda: str(uuid.uuid4()),
+        index=True,
+    )
     email = Column(String, unique=True, index=True, nullable=False)
     hashed_password = Column(String, nullable=False)
     created_at = Column(

--- a/scripts/compare_cold_start.py
+++ b/scripts/compare_cold_start.py
@@ -1,0 +1,256 @@
+"""
+Compare cold-start candidate pool strategies:
+  A) top-k cosine  → MMR rerank
+  B) cluster-sampled pool → MMR rerank   (our fix for popularity bias)
+
+Metrics per profile: ILD, avg_sim, brand diversity
+Cross-user metrics:  catalog coverage, inter-user Jaccard overlap
+Coverage scaling:    how coverage grows as we add more diverse users
+"""
+
+import json
+import warnings
+
+warnings.filterwarnings("ignore")
+import random
+
+import numpy as np
+import pandas as pd
+from pathlib import Path
+from sklearn.cluster import MiniBatchKMeans
+from sklearn.metrics.pairwise import cosine_similarity as sk_cosine
+
+from skincarelib.ml_system.reranker import (
+    rerank_candidates,
+    build_diverse_candidate_pool,
+)
+from skincarelib.models.user_profile import build_user_vector
+
+root = Path(__file__).resolve().parent.parent
+vectors = np.load(root / "artifacts/product_vectors.npy")
+with open(root / "artifacts/product_index.json") as f:
+    product_index = json.load(f)
+index_to_id = {v: k for k, v in product_index.items()}
+
+print(f"Catalog: {vectors.shape[0]} products, {vectors.shape[1]} dims")
+
+print("Fitting MiniBatchKMeans (20 clusters)...")
+mbk = MiniBatchKMeans(n_clusters=20, random_state=42, n_init=3, batch_size=2048)
+labels = mbk.fit_predict(vectors)
+cluster_to_ids: dict = {}
+for vi, ci in enumerate(labels):
+    pid = index_to_id.get(vi)
+    if pid is not None:
+        cluster_to_ids.setdefault(int(ci), []).append(pid)
+print("Done.\n")
+
+meta = pd.read_csv(root / "data/processed/products_with_signals.csv")
+meta["product_id"] = meta.index.astype(str)
+pid_to_brand = dict(zip(meta["product_id"], meta["brand"]))
+
+TOP_N = 10
+POOL_SIZE = 200
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def top_k_cosine_pool(user_vec, k=POOL_SIZE):
+    """O(N) top-k by dot product — no pairwise matrix."""
+    sims = vectors @ user_vec / (np.linalg.norm(vectors, axis=1) + 1e-9)
+    top_idx = np.argpartition(sims, -k)[-k:]
+    top_idx = top_idx[np.argsort(sims[top_idx])[::-1]]
+    return [index_to_id[i] for i in top_idx if i in index_to_id]
+
+
+def cluster_pool(user_vec):
+    return build_diverse_candidate_pool(
+        user_vector=user_vec,
+        kmeans=mbk,
+        cluster_to_ids=cluster_to_ids,
+        product_vectors=vectors,
+        product_index=product_index,
+        pool_size=POOL_SIZE,
+    )
+
+
+def ild(pids):
+    vecs = [vectors[product_index[p]] for p in pids if p in product_index]
+    if len(vecs) < 2:
+        return None
+    M = sk_cosine(vecs)
+    n = len(vecs)
+    tri = [M[i, j] for i in range(n) for j in range(i + 1, n)]
+    return round(float(1 - np.mean(tri)), 4)
+
+
+def avg_sim(user_vec, pids):
+    vecs = [vectors[product_index[p]] for p in pids if p in product_index]
+    if not vecs:
+        return None
+    return round(float(sk_cosine(user_vec.reshape(1, -1), vecs).mean()), 4)
+
+
+def run(user_vec, pool_fn):
+    pool = pool_fn(user_vec)
+    return rerank_candidates(user_vec, pool, vectors, product_index, top_n=TOP_N)
+
+
+# ── 5 core profiles ───────────────────────────────────────────────────────────
+CORE_PROFILES = [
+    {
+        "name": "oily_acne_budget",
+        "skin_type": "oily",
+        "concerns": ["acne", "large_pores"],
+        "sensitivity_level": "rarely_sensitive",
+        "budget": 25.0,
+        "preferred_categories": ["Cleanser", "Treatment"],
+        "preferred_ingredients": [],
+        "banned_ingredients": [],
+    },
+    {
+        "name": "dry_aging_premium",
+        "skin_type": "dry",
+        "concerns": ["fine_lines", "dullness"],
+        "sensitivity_level": "not_sensitive",
+        "budget": 200.0,
+        "preferred_categories": ["Moisturizer", "Treatment"],
+        "preferred_ingredients": [],
+        "banned_ingredients": [],
+    },
+    {
+        "name": "sensitive_redness",
+        "skin_type": "sensitive",
+        "concerns": ["redness", "dryness"],
+        "sensitivity_level": "very_sensitive",
+        "budget": 100.0,
+        "preferred_categories": ["Moisturizer"],
+        "preferred_ingredients": [],
+        "banned_ingredients": [],
+    },
+    {
+        "name": "combo_dark_spots",
+        "skin_type": "combination",
+        "concerns": ["dark_spots", "oiliness"],
+        "sensitivity_level": "somewhat_sensitive",
+        "budget": 50.0,
+        "preferred_categories": ["Treatment", "Moisturizer"],
+        "preferred_ingredients": [],
+        "banned_ingredients": [],
+    },
+    {
+        "name": "normal_maintenance",
+        "skin_type": "normal",
+        "concerns": ["maintenance"],
+        "sensitivity_level": "not_sensitive",
+        "budget": None,
+        "preferred_categories": [],
+        "preferred_ingredients": [],
+        "banned_ingredients": [],
+    },
+]
+
+# ── Per-profile comparison ────────────────────────────────────────────────────
+print(f"{'Profile':<25} {'Method':<14} {'ILD':>7} {'avg_sim':>9} {'brands':>8}")
+print("─" * 68)
+
+cosine_sets, cluster_sets = [], []
+for p in CORE_PROFILES:
+    prefs = {k: v for k, v in p.items() if k != "name"}
+    uv = build_user_vector(
+        liked_product_ids=[],
+        explicit_prefs=prefs,
+        product_vectors=vectors,
+        product_index=product_index,
+    )
+    cr = run(uv, top_k_cosine_pool)
+    cl = run(uv, cluster_pool)
+    cosine_sets.append(set(cr))
+    cluster_sets.append(set(cl))
+    for method, recs in [("cosine+MMR", cr), ("cluster+MMR", cl)]:
+        brands = len({pid_to_brand.get(pid, "?") for pid in recs})
+        print(
+            f"{p['name']:<25} {method:<14} {str(ild(recs)):>7} {str(avg_sim(uv, recs)):>9} {brands:>8}"
+        )
+    print()
+
+# ── Cross-user (5 profiles) ───────────────────────────────────────────────────
+print("── Cross-user metrics (5 core profiles) ─────────────────────────────────")
+for label, sets in [("cosine+MMR", cosine_sets), ("cluster+MMR", cluster_sets)]:
+    unique = set().union(*sets)
+    cov = round(len(unique) / len(product_index) * 100, 3)
+    pairs, jsum = 0, 0.0
+    for i in range(len(sets)):
+        for j in range(i + 1, len(sets)):
+            inter = len(sets[i] & sets[j])
+            union = len(sets[i] | sets[j])
+            jsum += inter / union if union else 0
+            pairs += 1
+    avg_j = round(jsum / pairs, 4) if pairs else 0
+    print(
+        f"  {label:<14}  coverage={cov}%  inter_user_jaccard={avg_j}  unique={len(unique)}"
+    )
+
+# ── Coverage scaling: 5 → 10 → 20 → 50 users ─────────────────────────────────
+print("\n── Coverage scaling (50 diverse synthetic users) ─────────────────────────")
+skin_types = ["oily", "dry", "sensitive", "combination", "normal"]
+concern_sets = [
+    ["acne", "large_pores"],
+    ["fine_lines", "dullness"],
+    ["redness", "dryness"],
+    ["dark_spots", "oiliness"],
+    ["maintenance"],
+    ["dryness", "fine_lines"],
+    ["acne", "redness"],
+    ["dullness", "dark_spots"],
+]
+budgets = [25.0, 50.0, 100.0, 200.0, None]
+sensitivities = [
+    "very_sensitive",
+    "somewhat_sensitive",
+    "rarely_sensitive",
+    "not_sensitive",
+]
+cat_sets = [
+    ["Cleanser", "Treatment"],
+    ["Moisturizer"],
+    ["Treatment", "Moisturizer"],
+    ["Cleanser"],
+    [],
+    ["Moisturizer", "Treatment"],
+]
+
+random.seed(42)
+synthetic = [
+    {
+        "skin_type": random.choice(skin_types),
+        "concerns": random.choice(concern_sets),
+        "sensitivity_level": random.choice(sensitivities),
+        "budget": random.choice(budgets),
+        "preferred_categories": random.choice(cat_sets),
+        "preferred_ingredients": [],
+        "banned_ingredients": [],
+    }
+    for _ in range(50)
+]
+
+cosine_all, cluster_all = [], []
+for p in synthetic:
+    uv = build_user_vector(
+        liked_product_ids=[],
+        explicit_prefs=p,
+        product_vectors=vectors,
+        product_index=product_index,
+    )
+    cosine_all.append(set(run(uv, top_k_cosine_pool)))
+    cluster_all.append(set(run(uv, cluster_pool)))
+
+print(
+    f"  {'users':<8} {'cosine_cov':>12} {'cluster_cov':>13} {'cosine_unique':>14} {'cluster_unique':>15}"
+)
+print("  " + "─" * 65)
+for n in [5, 10, 20, 30, 50]:
+    cu = set().union(*cosine_all[:n])
+    cl = set().union(*cluster_all[:n])
+    cc = round(len(cu) / len(product_index) * 100, 3)
+    clc = round(len(cl) / len(product_index) * 100, 3)
+    print(f"  {n:<8} {cc:>11}%  {clc:>12}%  {len(cu):>14}  {len(cl):>15}")

--- a/scripts/eval_cf.py
+++ b/scripts/eval_cf.py
@@ -1,0 +1,472 @@
+"""
+Synthetic evaluation: content-based vs CF vs hybrid.
+
+Generates 500 pseudo-users across 5 profile types, simulates interactions from
+product signals, splits 80/20 train/test per user, and evaluates:
+  - Content-only  (Rocchio user vector + MMR)
+  - CF-only       (item-based co-occurrence CF)
+  - Hybrid α=0.25 (25% content, 75% CF)
+  - Hybrid α=0.50 (50/50)
+  - Hybrid α=0.75 (75% content, 25% CF)
+
+Reports NDCG@10, Precision@10, ILD, avg_sim per model.
+Also tunes MMR lambda_mult and hybrid alpha over a hold-out slice.
+"""
+
+import json
+import warnings
+
+warnings.filterwarnings("ignore")
+import random
+import sys
+from pathlib import Path
+
+import numpy as np
+from sklearn.metrics.pairwise import cosine_similarity as sk_cosine
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from skincarelib.ml_system.collab_filter import ItemBasedCF
+from skincarelib.ml_system.reranker import rerank_candidates
+from skincarelib.models.user_profile import build_user_vector
+
+# ── Load artifacts ─────────────────────────────────────────────────────────────
+vectors = np.load(ROOT / "artifacts/product_vectors.npy")
+with open(ROOT / "artifacts/product_index.json") as f:
+    product_index = json.load(f)
+
+N_PRODUCTS = vectors.shape[0]
+SIGNAL_DIMS = [629, 630, 631, 632, 633, 634, 635]  # hydration..irritation_risk
+SIGNAL_NAMES = [
+    "hydration",
+    "barrier",
+    "acne_control",
+    "soothing",
+    "exfoliation",
+    "antioxidant",
+    "irritation_risk",
+]
+
+print(f"Catalog: {N_PRODUCTS} products, {vectors.shape[1]} dims")
+
+# ── Profile type definitions ───────────────────────────────────────────────────
+# Each profile specifies which signal dims they prefer (high values are good)
+# and which they avoid. Used to compute interaction probability.
+PROFILE_TYPES = [
+    {
+        "name": "oily_acne_budget",
+        "prefs": {
+            "skin_type": "oily",
+            "concerns": ["acne", "large_pores"],
+            "sensitivity_level": "rarely_sensitive",
+            "budget": 25.0,
+            "preferred_categories": ["Cleanser", "Treatment"],
+            "preferred_ingredients": [],
+            "banned_ingredients": [],
+        },
+        "signal_weights": np.array([0.1, -0.1, 0.8, 0.2, 0.5, 0.3, -0.7]),
+    },
+    {
+        "name": "dry_aging_premium",
+        "prefs": {
+            "skin_type": "dry",
+            "concerns": ["fine_lines", "dullness"],
+            "sensitivity_level": "not_sensitive",
+            "budget": 200.0,
+            "preferred_categories": ["Moisturizer", "Treatment"],
+            "preferred_ingredients": [],
+            "banned_ingredients": [],
+        },
+        "signal_weights": np.array([0.8, 0.6, -0.2, 0.4, 0.2, 0.7, -0.3]),
+    },
+    {
+        "name": "sensitive_redness",
+        "prefs": {
+            "skin_type": "sensitive",
+            "concerns": ["redness", "dryness"],
+            "sensitivity_level": "very_sensitive",
+            "budget": 100.0,
+            "preferred_categories": ["Moisturizer"],
+            "preferred_ingredients": [],
+            "banned_ingredients": [],
+        },
+        "signal_weights": np.array([0.5, 0.7, -0.1, 0.9, -0.3, 0.1, -1.0]),
+    },
+    {
+        "name": "combo_dark_spots",
+        "prefs": {
+            "skin_type": "combination",
+            "concerns": ["dark_spots", "oiliness"],
+            "sensitivity_level": "somewhat_sensitive",
+            "budget": 50.0,
+            "preferred_categories": ["Treatment", "Moisturizer"],
+            "preferred_ingredients": [],
+            "banned_ingredients": [],
+        },
+        "signal_weights": np.array([0.2, 0.1, 0.4, 0.3, 0.5, 0.8, -0.5]),
+    },
+    {
+        "name": "normal_maintenance",
+        "prefs": {
+            "skin_type": "normal",
+            "concerns": ["maintenance"],
+            "sensitivity_level": "not_sensitive",
+            "budget": None,
+            "preferred_categories": [],
+            "preferred_ingredients": [],
+            "banned_ingredients": [],
+        },
+        "signal_weights": np.array([0.4, 0.3, 0.1, 0.2, 0.2, 0.5, -0.2]),
+    },
+]
+
+# ── Precompute product signal matrix ──────────────────────────────────────────
+product_signals = vectors[:, SIGNAL_DIMS]  # (N, 7)
+
+
+def like_probability(signal_weights: np.ndarray, product_idx: int) -> float:
+    """Sigmoid of dot product between user preference weights and product signals."""
+    x = float(np.dot(signal_weights, product_signals[product_idx]))
+    return 1.0 / (1.0 + np.exp(-3.0 * x))
+
+
+# ── Generate synthetic users ──────────────────────────────────────────────────
+N_USERS = 500
+N_INTERACTIONS = 25  # per user
+TRAIN_FRAC = 0.8
+
+random.seed(42)
+np.random.seed(42)
+
+id_to_idx = {str(pid): idx for pid, idx in product_index.items()}
+
+print(f"Generating {N_USERS} synthetic users ({N_INTERACTIONS} interactions each)...")
+
+users = []
+for u in range(N_USERS):
+    ptype = PROFILE_TYPES[u % len(PROFILE_TYPES)]
+    # Slightly vary signal weights per user for diversity
+    noise = np.random.normal(0, 0.1, size=7)
+    sw = ptype["signal_weights"] + noise
+
+    # Sample products to interact with — stratified so not all are top-similarity
+    # Sample 3× more than needed, then filter by probability
+    sample_size = N_INTERACTIONS * 6
+    sampled_idx = np.random.choice(
+        N_PRODUCTS, size=min(sample_size, N_PRODUCTS), replace=False
+    )
+
+    interactions = []
+    for pidx in sampled_idx:
+        p = like_probability(sw, pidx)
+        liked = np.random.random() < p
+        pid = None
+        for k, v in product_index.items():
+            if v == pidx:
+                pid = str(k)
+                break
+        if pid is not None:
+            interactions.append((str(u), pid, liked))
+        if len(interactions) >= N_INTERACTIONS:
+            break
+
+    if len(interactions) < 5:
+        continue  # skip users with too few interactions
+
+    n_train = max(1, int(len(interactions) * TRAIN_FRAC))
+    train = interactions[:n_train]
+    test = interactions[n_train:]
+
+    # Ground truth: test items that were liked
+    test_liked = {pid for _, pid, liked in test if liked}
+    if not test_liked:
+        continue
+
+    users.append(
+        {
+            "user_id": str(u),
+            "profile": ptype,
+            "signal_weights": sw,
+            "train": train,
+            "test": test,
+            "test_liked": test_liked,
+            "train_liked": [pid for _, pid, liked in train if liked],
+        }
+    )
+
+print(f"Valid users: {len(users)}")
+
+# ── Build user product_index (needed by build_user_vector) ────────────────────
+# product_index maps str product_id -> int row index (already loaded above)
+
+# ── Build CF model ─────────────────────────────────────────────────────────────
+print("Fitting ItemBasedCF...")
+all_train = [interaction for u in users for interaction in u["train"]]
+cf = ItemBasedCF()
+cf.fit(all_train)
+print(f"CF fitted on {len(all_train)} interactions, {cf.n_items} items")
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+def ild(pids):
+    vecs = [vectors[product_index[p]] for p in pids if p in product_index]
+    if len(vecs) < 2:
+        return None
+    M = sk_cosine(vecs)
+    n = len(vecs)
+    tri = [M[i, j] for i in range(n) for j in range(i + 1, n)]
+    return float(1 - np.mean(tri))
+
+
+def avg_sim_score(user_vec, pids):
+    vecs = [vectors[product_index[p]] for p in pids if p in product_index]
+    if not vecs:
+        return None
+    return float(sk_cosine(user_vec.reshape(1, -1), vecs).mean())
+
+
+# Precompute once — used by all ranking helpers to avoid rebuilding per call
+_idx_to_pid = {v: k for k, v in product_index.items()}
+
+
+def ndcg_at_k(recs, relevant_set, k=10):
+    """Compute NDCG@k. Relevant = products in test_liked."""
+    dcg = 0.0
+    for i, pid in enumerate(recs[:k]):
+        if pid in relevant_set:
+            dcg += 1.0 / np.log2(i + 2)
+    ideal_n = min(len(relevant_set), k)
+    idcg = sum(1.0 / np.log2(i + 2) for i in range(ideal_n))
+    return dcg / idcg if idcg > 0 else 0.0
+
+
+def precision_at_k(recs, relevant_set, k=10):
+    hits = sum(1 for pid in recs[:k] if pid in relevant_set)
+    return hits / k
+
+
+def mean_rank_of_relevant(recs, relevant_set):
+    """Mean 1-based rank of relevant items in the ranked list. None if no hits."""
+    ranks = [i + 1 for i, pid in enumerate(recs) if pid in relevant_set]
+    return float(np.mean(ranks)) if ranks else None
+
+
+def _cosine_rank(user_vec, exclude_ids, top_n=100):
+    """Pure cosine ranking — O(N) dot products + argsort. Used for NDCG/mean_rank.
+
+    MMR is a serving diversity tool, not a retrieval model. NDCG@k should be
+    measured against the retrieval ranking (cosine), not the diversity reranking.
+    """
+    norms = np.linalg.norm(vectors, axis=1) + 1e-9
+    sims = vectors @ user_vec / norms
+    exclude_set = set(exclude_ids)
+    top_idx = np.argsort(sims)[::-1]
+    return [_idx_to_pid[i] for i in top_idx if _idx_to_pid.get(i) not in exclude_set][
+        :top_n
+    ]
+
+
+def get_content_recs(user_vec, exclude_ids, top_n=10, lambda_mult=0.7):
+    """Top-200 cosine pool → MMR rerank to top_n for serving metrics (ILD, avg_sim)."""
+    pool = _cosine_rank(user_vec, exclude_ids, top_n=200)
+    return rerank_candidates(
+        user_vec, pool, vectors, product_index, top_n=top_n, lambda_mult=lambda_mult
+    )
+
+
+def get_cf_recs(seed_ids, exclude_ids, all_pids, top_n=100):
+    """CF score all candidates, return top_n."""
+    exclude_set = set(exclude_ids)
+    candidates = [p for p in all_pids if p not in exclude_set][:2000]
+    cf_scores = cf.score(seed_ids, candidates)
+    order = np.argsort(cf_scores)[::-1]
+    return [candidates[i] for i in order[:top_n]]
+
+
+def get_hybrid_ranked(user_vec, seed_ids, exclude_ids, top_n=100):
+    """
+    Hybrid cosine+CF ranking (no MMR) — used for NDCG/mean_rank evaluation.
+    alpha=0.5: equal weight on normalised content and CF scores.
+    """
+    exclude_set = set(exclude_ids)
+    norms = np.linalg.norm(vectors, axis=1) + 1e-9
+    content_sims = vectors @ user_vec / norms
+
+    top_content_idx = np.argsort(content_sims)[::-1]
+    candidates = [
+        _idx_to_pid[i] for i in top_content_idx if _idx_to_pid.get(i) not in exclude_set
+    ][:400]
+
+    content_scores = np.array(
+        [
+            content_sims[product_index[p]] if p in product_index else 0.0
+            for p in candidates
+        ],
+        dtype=np.float32,
+    )
+    cf_scores_arr = cf.score(seed_ids, candidates)
+
+    def norm01(x):
+        mn, mx = x.min(), x.max()
+        return (x - mn) / (mx - mn + 1e-9)
+
+    combined = 0.5 * norm01(content_scores) + 0.5 * norm01(cf_scores_arr)
+    order = np.argsort(combined)[::-1]
+    return [candidates[i] for i in order[:top_n]]
+
+
+# Build list of all known product IDs
+all_product_ids = list(product_index.keys())
+
+# ── Evaluate models ────────────────────────────────────────────────────────────
+# NDCG and mean_rank use pure cosine ranking (fast, no MMR overhead).
+# ILD and avg_sim use MMR top-10 (the actual serving output).
+# This separation is intentional: NDCG measures retrieval quality;
+# MMR is a post-retrieval diversity step that shouldn't affect the retrieval score.
+RANK_FNS = {
+    "content": lambda u, lm: _cosine_rank(u["user_vec"], u["train_liked"], top_n=100),
+    "cf": lambda u, _: get_cf_recs(
+        u["train_liked"], u["train_liked"], all_product_ids, top_n=100
+    ),
+    "hybrid_0.50": lambda u, lm: get_hybrid_ranked(
+        u["user_vec"], u["train_liked"], u["train_liked"], top_n=100
+    ),
+}
+SERVE_FNS = {
+    "content": lambda u, lm: get_content_recs(
+        u["user_vec"], u["train_liked"], top_n=10, lambda_mult=lm
+    ),
+    "cf": lambda u, _: get_cf_recs(
+        u["train_liked"], u["train_liked"], all_product_ids, top_n=10
+    ),
+    "hybrid_0.50": lambda u, lm: get_hybrid_ranked(
+        u["user_vec"], u["train_liked"], u["train_liked"], top_n=10
+    ),
+}
+
+LAMBDA_MULTS = [0.3, 0.5, 0.7, 0.9]
+
+print("\nBuilding user vectors...")
+for u in users:
+    u["user_vec"] = build_user_vector(
+        liked_product_ids=u["train_liked"],
+        explicit_prefs=u["profile"]["prefs"],
+        product_vectors=vectors,
+        product_index=product_index,
+    )
+
+print("Done. Running evaluations...\n")
+
+# ── Lambda tuning (content model only, on first 100 users) ────────────────────
+# NDCG tuning: vary MMR lambda — but since NDCG uses pure cosine rank,
+# we're actually tuning ILD here (lambda only affects serving diversity).
+print("── MMR lambda_mult tuning — ILD@10 vs diversity tradeoff (100 users) ──────")
+print(f"{'lambda_mult':<14} {'ILD@10':>8} {'avg_sim@10':>12}")
+print("─" * 38)
+
+tune_users = users[:100]
+best_lm = 0.7  # default; tune by ILD if needed
+for lm in LAMBDA_MULTS:
+    ilds, sims = [], []
+    for u in tune_users:
+        recs = get_content_recs(
+            u["user_vec"], u["train_liked"], top_n=10, lambda_mult=lm
+        )
+        il = ild(recs)
+        if il is not None:
+            ilds.append(il)
+        s = avg_sim_score(u["user_vec"], recs)
+        if s is not None:
+            sims.append(s)
+    print(
+        f"{lm:<14.2f} {float(np.mean(ilds)) if ilds else 0:>8.4f} {float(np.mean(sims)) if sims else 0:>12.4f}"
+    )
+
+print(f"\nUsing lambda_mult={best_lm} for serving metrics.\n")
+
+# ── Full model comparison (remaining users) ───────────────────────────────────
+eval_users = users[100:]
+print(
+    f"── Full model comparison ({len(eval_users)} users) ──────────────────────────────────"
+)
+print(
+    f"{'Model':<16} {'NDCG@10':>8} {'NDCG@100':>10} {'P@10':>6} {'mean_rank':>10} {'ILD@10':>8} {'avg_sim':>9}"
+)
+print("─" * 76)
+
+results = {}
+for model_name in RANK_FNS:
+    rank_fn = RANK_FNS[model_name]
+    serve_fn = SERVE_FNS[model_name]
+    n10, n100, precs, ranks, ilds_list, sims = [], [], [], [], [], []
+    for u in eval_users:
+        try:
+            ranked = rank_fn(u, best_lm)  # pure cosine / CF rank — for NDCG
+            served = serve_fn(u, best_lm)  # MMR top-10 — for ILD, avg_sim
+        except Exception:
+            continue
+        if not ranked:
+            continue
+        n10.append(ndcg_at_k(ranked, u["test_liked"], k=10))
+        n100.append(ndcg_at_k(ranked, u["test_liked"], k=100))
+        precs.append(precision_at_k(ranked, u["test_liked"], k=10))
+        mr = mean_rank_of_relevant(ranked, u["test_liked"])
+        if mr is not None:
+            ranks.append(mr)
+        il = ild(served)
+        if il is not None:
+            ilds_list.append(il)
+        s = avg_sim_score(u["user_vec"], served)
+        if s is not None:
+            sims.append(s)
+
+    r = {
+        "ndcg10": float(np.mean(n10)) if n10 else 0.0,
+        "ndcg100": float(np.mean(n100)) if n100 else 0.0,
+        "precision": float(np.mean(precs)) if precs else 0.0,
+        "mean_rank": float(np.mean(ranks)) if ranks else None,
+        "ild": float(np.mean(ilds_list)) if ilds_list else 0.0,
+        "avg_sim": float(np.mean(sims)) if sims else 0.0,
+        "n": len(n10),
+    }
+    results[model_name] = r
+    mr_str = f"{r['mean_rank']:.1f}" if r["mean_rank"] is not None else "none"
+    print(
+        f"{model_name:<16} {r['ndcg10']:>8.4f} {r['ndcg100']:>10.4f} {r['precision']:>6.4f} "
+        f"{mr_str:>10} {r['ild']:>8.4f} {r['avg_sim']:>9.4f}"
+    )
+
+# ── Per-profile breakdown ─────────────────────────────────────────────────────
+print("\n── Per-profile breakdown (content vs hybrid_0.50) ────────────────────────")
+print(
+    f"{'Profile':<25} {'Model':<16} {'NDCG@10':>8} {'NDCG@100':>10} {'mean_rank':>10}"
+)
+print("─" * 74)
+
+for pname in [pt["name"] for pt in PROFILE_TYPES]:
+    ptype_users = [u for u in eval_users if u["profile"]["name"] == pname]
+    if not ptype_users:
+        continue
+    for model_name in ["content", "hybrid_0.50"]:
+        rank_fn = RANK_FNS[model_name]
+        n10, n100, ranks = [], [], []
+        for u in ptype_users:
+            try:
+                ranked = rank_fn(u, best_lm)
+            except Exception:
+                continue
+            if not ranked:
+                continue
+            n10.append(ndcg_at_k(ranked, u["test_liked"], k=10))
+            n100.append(ndcg_at_k(ranked, u["test_liked"], k=100))
+            mr = mean_rank_of_relevant(ranked, u["test_liked"])
+            if mr is not None:
+                ranks.append(mr)
+        nd10 = float(np.mean(n10)) if n10 else 0.0
+        nd100 = float(np.mean(n100)) if n100 else 0.0
+        mr_str = f"{float(np.mean(ranks)):.1f}" if ranks else "none"
+        print(f"{pname:<25} {model_name:<16} {nd10:>8.4f} {nd100:>10.4f} {mr_str:>10}")
+    print()
+
+print("Done.")

--- a/scripts/populate_dupes.py
+++ b/scripts/populate_dupes.py
@@ -37,9 +37,9 @@ if not SUPABASE_URL or not SUPABASE_KEY:
 
 supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
 
-BATCH_SIZE = 100        # rows per supabase insert
-TOP_N = 3              # dupes per product
-LOG_EVERY = 500         # print progress every N products
+BATCH_SIZE = 100  # rows per supabase insert
+TOP_N = 3  # dupes per product
+LOG_EVERY = 500  # print progress every N products
 
 
 def run():
@@ -57,15 +57,17 @@ def run():
             results = find_dupes(product_id, top_n=TOP_N, explain=True)
 
             for _, row in results.iterrows():
-                batch.append({
-                    "source_product_id": int(product_id),
-                    "dupe_product_id":   int(row["product_id"]),
-                    "dupe_score":        float(row["dupe_score"]),
-                    "cosine_sim":        float(row["cosine_sim"]),
-                    "price_score":       float(row["price_score"]),
-                    "ingredient_group_score": float(row["ingredient_group_score"]),
-                    "explanation":       str(row.get("explanation", "")),
-                })
+                batch.append(
+                    {
+                        "source_product_id": int(product_id),
+                        "dupe_product_id": int(row["product_id"]),
+                        "dupe_score": float(row["dupe_score"]),
+                        "cosine_sim": float(row["cosine_sim"]),
+                        "price_score": float(row["price_score"]),
+                        "ingredient_group_score": float(row["ingredient_group_score"]),
+                        "explanation": str(row.get("explanation", "")),
+                    }
+                )
 
         except ValueError:
             skipped += 1
@@ -82,7 +84,9 @@ def run():
             batch = []
 
         if (i + 1) % LOG_EVERY == 0:
-            print(f"  [{i+1}/{total}] inserted={inserted} skipped={skipped} errors={errors}")
+            print(
+                f"  [{i + 1}/{total}] inserted={inserted} skipped={skipped} errors={errors}"
+            )
 
     # flush remaining
     if batch:
@@ -96,8 +100,7 @@ def _flush(batch: list):
     """Insert a batch of rows, ignoring duplicates."""
     try:
         supabase.table("product_dupes").upsert(
-            batch,
-            on_conflict="source_product_id,dupe_product_id"
+            batch, on_conflict="source_product_id,dupe_product_id"
         ).execute()
     except Exception as e:
         print(f"  Supabase flush error: {e}")

--- a/skincarelib/ml_system/collab_filter.py
+++ b/skincarelib/ml_system/collab_filter.py
@@ -1,0 +1,105 @@
+"""
+Item-based Collaborative Filtering using interaction co-occurrence.
+
+Classical neighborhood CF: items are similar if many users co-interacted with them.
+Separate from EmbeddingCollaborativeFilter (which is a user-profile embedding model,
+not cross-user CF).
+
+Usage:
+    cf = ItemBasedCF()
+    cf.fit(interactions)           # interactions: list of (user_id, product_id, liked)
+    scores = cf.score(seen_ids, candidate_ids)
+"""
+
+from typing import Dict, List, Tuple
+
+import numpy as np
+from collections import defaultdict
+
+
+class ItemBasedCF:
+    """
+    Item-based CF via co-occurrence: two items are similar if users who liked one
+    also tended to like the other.
+
+    Fit:
+        Build a co-occurrence count matrix over liked interactions only.
+        Normalise by each item's total co-occurrence count (column-wise L1) to get
+        an item-item "association" score analogous to adjusted cosine.
+
+    Score:
+        For a set of seed items the user already liked, sum the association scores
+        toward each candidate item and return those sums as CF scores.
+    """
+
+    def __init__(self):
+        # item_id -> dict{other_item_id -> float co-occurrence count}
+        self._cooccur: Dict[str, Dict[str, float]] = {}
+        self._item_totals: Dict[str, float] = {}
+        self._fitted = False
+
+    def fit(self, interactions: List[Tuple[str, str, bool]]) -> "ItemBasedCF":
+        """
+        Build co-occurrence from interactions.
+
+        Args:
+            interactions: list of (user_id, product_id, liked)
+                          Only liked=True interactions are used.
+        """
+        # Group liked product IDs per user
+        user_likes: Dict[str, List[str]] = defaultdict(list)
+        for uid, pid, liked in interactions:
+            if liked:
+                user_likes[str(uid)].append(str(pid))
+
+        cooccur: Dict[str, Dict[str, float]] = defaultdict(lambda: defaultdict(float))
+        for pids in user_likes.values():
+            for i, a in enumerate(pids):
+                for b in pids:
+                    if a != b:
+                        cooccur[a][b] += 1.0
+
+        # Normalise each row by total co-occurrence count
+        self._cooccur = {}
+        self._item_totals = {}
+        for item, nbrs in cooccur.items():
+            total = sum(nbrs.values())
+            self._item_totals[item] = total
+            if total > 0:
+                self._cooccur[item] = {k: v / total for k, v in nbrs.items()}
+            else:
+                self._cooccur[item] = {}
+
+        self._fitted = True
+        return self
+
+    def score(
+        self,
+        seed_ids: List[str],
+        candidate_ids: List[str],
+    ) -> np.ndarray:
+        """
+        Score candidates given seed items the user liked.
+
+        Args:
+            seed_ids:      product IDs the user has liked (training set)
+            candidate_ids: product IDs to score
+
+        Returns:
+            np.ndarray shape (len(candidate_ids),) — CF association scores.
+            Products not seen during fit score 0.
+        """
+        if not self._fitted or not seed_ids:
+            return np.zeros(len(candidate_ids), dtype=np.float32)
+
+        scores = np.zeros(len(candidate_ids), dtype=np.float32)
+        for i, cid in enumerate(candidate_ids):
+            s = 0.0
+            for seed in seed_ids:
+                s += self._cooccur.get(seed, {}).get(cid, 0.0)
+            scores[i] = s
+        return scores
+
+    @property
+    def n_items(self) -> int:
+        return len(self._cooccur)

--- a/skincarelib/ml_system/reranker.py
+++ b/skincarelib/ml_system/reranker.py
@@ -42,7 +42,6 @@ def rerank_candidates(
 
     while len(selected) < min(top_n, len(valid_ids)):
         if not selected:
-            # First pick: no selected set yet, just take most relevant
             best = max(remaining, key=lambda i: relevance[i])
         else:
             best, best_score = None, -np.inf
@@ -56,6 +55,59 @@ def rerank_candidates(
         remaining.remove(best)
 
     return [valid_ids[i] for i in selected]
+
+
+def build_diverse_candidate_pool(
+    user_vector: np.ndarray,
+    kmeans,
+    cluster_to_ids: Dict[int, List[str]],
+    product_vectors: np.ndarray,
+    product_index: Dict[str, int],
+    pool_size: int = 200,
+    top_clusters: int = 8,
+) -> List[str]:
+    """
+    Build a diverse candidate pool by sampling from multiple clusters proportionally.
+
+    The problem with top-k cosine as a pre-filter: it always pulls from the same
+    high-norm products that have large dot products with almost any user vector,
+    which causes catalog coverage to flatline even as user diversity increases.
+
+    This function instead:
+    1. Scores all cluster centroids against the user vector (O(K), very cheap)
+    2. Takes the top_clusters closest clusters
+    3. Allocates pool slots proportionally to centroid similarity
+       (closer cluster gets more slots, but every cluster gets at least some)
+    4. Within each cluster, picks the best candidates by cosine similarity
+
+    The resulting pool is passed to rerank_candidates for final MMR reranking.
+    """
+    centroid_sims = cosine_similarity(
+        user_vector.reshape(1, -1), kmeans.cluster_centers_
+    ).flatten()
+    best_clusters = np.argsort(centroid_sims)[::-1][:top_clusters]
+
+    # Proportional slot allocation — weight by centroid similarity, floor at 1
+    best_sims = np.maximum(centroid_sims[best_clusters], 0.0)
+    total = best_sims.sum()
+    if total < 1e-9:
+        allocations = [pool_size // top_clusters] * top_clusters
+    else:
+        allocations = [max(1, int(pool_size * s / total)) for s in best_sims]
+
+    pool: List[str] = []
+    for cid, alloc in zip(best_clusters, allocations):
+        cluster_pids = [
+            p for p in cluster_to_ids.get(int(cid), []) if p in product_index
+        ]
+        if not cluster_pids:
+            continue
+        cvecs = product_vectors[[product_index[p] for p in cluster_pids]]
+        sims = cosine_similarity(user_vector.reshape(1, -1), cvecs).flatten()
+        top_in = np.argsort(sims)[::-1][:alloc]
+        pool.extend(cluster_pids[i] for i in top_in)
+
+    return pool
 
 
 def mock_candidates_similarity_seed(

--- a/skincarelib/models/dupe_explainer.py
+++ b/skincarelib/models/dupe_explainer.py
@@ -9,11 +9,11 @@ def explain_dupe(source_row, candidate_row) -> str:
     data points. Avoids exposing internal metrics (cosine scores, group
     counts) that are meaningful to engineers but not to end users.
     """
-    source_name  = _short_name(source_row)
+    source_name = _short_name(source_row)
     source_price = float(source_row.get("price", 0.0))
-    cand_price   = float(candidate_row.get("price", 0.0))
-    cosine       = float(candidate_row.get("cosine_sim", 0.0))
-    ig_score     = float(candidate_row.get("ingredient_group_score", 0.0))
+    cand_price = float(candidate_row.get("price", 0.0))
+    cosine = float(candidate_row.get("cosine_sim", 0.0))
+    ig_score = float(candidate_row.get("ingredient_group_score", 0.0))
 
     # --- ingredient similarity phrase ---
     if cosine >= 0.90:
@@ -52,25 +52,19 @@ def explain_dupe(source_row, candidate_row) -> str:
                 f"(${cand_price:.2f} vs ${source_price:.2f})"
             )
         elif savings_pct >= 0.10:
-            price_phrase = (
-                f" for less "
-                f"(${cand_price:.2f} vs ${source_price:.2f})"
-            )
+            price_phrase = f" for less (${cand_price:.2f} vs ${source_price:.2f})"
 
-    return (
-        f"Has a {similarity} {source_name}, "
-        f"{function_phrase}{price_phrase}."
-    )
+    return f"Has a {similarity} {source_name}, {function_phrase}{price_phrase}."
 
 
 def _short_name(row) -> str:
     """Return a concise product identifier: 'Brand ProductName'."""
-    name  = str(row.get("product_name", row.get("name", "the original"))).strip()
+    name = str(row.get("product_name", row.get("name", "the original"))).strip()
     brand = str(row.get("brand", "")).strip()
 
     # strip brand prefix if already present in name
     if brand and name.lower().startswith(brand.lower()):
-        name = name[len(brand):].strip()
+        name = name[len(brand) :].strip()
 
     # trim at first comma to remove size/variant suffixes
     if "," in name:

--- a/skincarelib/models/recommender_ranker.py
+++ b/skincarelib/models/recommender_ranker.py
@@ -11,8 +11,6 @@ ROOT = Path(__file__).resolve().parent.parent.parent
 
 VECTORS_PATH = ROOT / "artifacts" / "product_vectors.npy"
 INDEX_PATH = ROOT / "artifacts" / "product_index.json"
-METADATA_PATH = ROOT / "data" / "processed" / "products_dataset_clean_tokens.csv"
-TOKENS_PATH = ROOT / "data" / "processed" / "products_dataset_clean_tokens.csv"
 SIGNALS_PATH = ROOT / "data" / "processed" / "products_with_signals.csv"
 
 _SIGNAL_COLS = [
@@ -44,9 +42,6 @@ def load_artifacts():
     with open(INDEX_PATH) as f:
         product_index = json.load(f)
 
-    metadata = pd.read_csv(METADATA_PATH, dtype={"product_id": str})
-    metadata.columns = metadata.columns.str.lower()
-    metadata["product_id"] = metadata.index.astype(str)
     metadata = pd.read_csv(SIGNALS_PATH)
 
     # Always derive product_id from row index to stay consistent with vectorizer.py,
@@ -125,14 +120,19 @@ def rank_products(
             tokens = {t.strip().lower() for t in token_string.split(",")}
             return tokens.isdisjoint(banned_set)
 
-        keep_cols = [c for c in candidates.columns]
-        merged = candidates.merge(
-            tokens_df[["product_id", "ingredient_tokens"]],
-            on="product_id",
-            how="left",
-        )
-        mask = merged["ingredient_tokens"].apply(has_no_banned)
-        candidates = merged[mask][keep_cols]
+        keep_cols = list(candidates.columns)
+        if "ingredient_tokens" in candidates.columns:
+            # tokens already present in metadata — use directly, skip merge
+            mask = candidates["ingredient_tokens"].apply(has_no_banned)
+            candidates = candidates[mask]
+        else:
+            merged = candidates.merge(
+                tokens_df[["product_id", "ingredient_tokens"]],
+                on="product_id",
+                how="left",
+            )
+            mask = merged["ingredient_tokens"].apply(has_no_banned)
+            candidates = merged[mask][keep_cols]
 
     # --- Filter 5: Exclude already-liked products ---
     liked_ids = constraints.get("liked_product_ids") or []

--- a/skincarelib/models/user_profile.py
+++ b/skincarelib/models/user_profile.py
@@ -67,7 +67,43 @@ SKIN_TYPE_SIGNAL_PREFS = {
     "normal": (["antioxidant", "hydration"], ["irritation_risk"]),
 }
 
-# Module-level caches — populated lazily on first call
+# Concern -> (signal dims to boost, signal dims to suppress)
+CONCERN_SIGNAL_PREFS = {
+    "acne": (["acne_control", "exfoliation"], ["barrier"]),
+    "dryness": (["hydration", "barrier", "soothing"], ["exfoliation"]),
+    "oiliness": (["acne_control", "exfoliation"], ["barrier", "hydration"]),
+    "redness": (["soothing", "barrier"], ["irritation_risk", "exfoliation"]),
+    "dark_spots": (["antioxidant", "exfoliation"], []),
+    "fine_lines": (["antioxidant", "hydration", "barrier"], []),
+    "dullness": (["antioxidant", "exfoliation"], []),
+    "large_pores": (["acne_control", "exfoliation"], ["barrier"]),
+    "maintenance": (["antioxidant", "hydration"], []),
+}
+
+# Sensitivity level -> irritation_risk suppress factor (0 = no change, 1 = zero out)
+SENSITIVITY_SUPPRESS = {
+    "very_sensitive": 0.0,  # fully suppress irritation_risk dim
+    "somewhat_sensitive": 0.4,
+    "rarely_sensitive": 0.7,
+    "not_sensitive": 1.0,  # no change
+    "not_sure": 0.7,  # conservative default
+}
+
+# ── Boost / suppress magnitudes ───────────────────────────────────────────────
+# Kept as module-level constants so they're easy to tune and test in isolation.
+_GROUP_BOOST_FACTOR = 0.3  # scale applied to catalog mean for group dim boost
+_GROUP_SUPPRESS_FACTOR = 0.5  # multiplicative suppression for group dims
+
+_SIGNAL_BOOST = 0.25  # additive boost for skin-type signal dims
+_SIGNAL_SUPPRESS = 0.5  # multiplicative suppression for skin-type signal dims
+
+_CONCERN_BOOST = 0.2  # additive boost per concern-aligned signal dim
+_CONCERN_SUPPRESS = 0.6  # multiplicative suppression per concern-opposed dim
+
+_INGREDIENT_BOOST = 0.15  # additive boost per preferred ingredient token
+_CATEGORY_BOOST = 0.5  # additive boost per preferred category dim
+
+# ── Module-level caches — populated lazily on first call ──────────────────────
 _group_map = None  # ingredient -> group name
 _group_names = None  # sorted list of unique group names
 _group_dim = None  # group name -> absolute dim index
@@ -167,7 +203,7 @@ def build_user_vector(
     else:
         base_vector = np.zeros(TOTAL_DIMS, dtype=np.float32)
 
-    # --- Step 2: Skin type -> group dim boost/suppress ---
+    # --- Step 2a: Skin type -> ingredient group dim boost/suppress ---
     skin_type = (explicit_prefs.get("skin_type") or "").lower().strip()
     if skin_type in SKIN_TYPE_PREFS:
         boost_groups, suppress_groups = SKIN_TYPE_PREFS[skin_type]
@@ -175,48 +211,61 @@ def build_user_vector(
         catalog_group_mean = product_vectors[
             :, GROUPS_START : GROUPS_START + len(_group_names)
         ].mean(axis=0)
-        BOOST_FACTOR = 0.3
-        SUPPRESS_FACTOR = 0.5
         for grp in boost_groups:
             if grp not in _group_dim:
                 continue
             dim = _group_dim[grp]
             group_offset = dim - GROUPS_START
-            delta = float(catalog_group_mean[group_offset]) * BOOST_FACTOR
+            delta = float(catalog_group_mean[group_offset]) * _GROUP_BOOST_FACTOR
             base_vector[dim] += delta
         for grp in suppress_groups:
             if grp not in _group_dim:
                 continue
-            base_vector[_group_dim[grp]] *= SUPPRESS_FACTOR
+            base_vector[_group_dim[grp]] *= _GROUP_SUPPRESS_FACTOR
 
-    # --- Step 2b: Skin type -> signal dim boost/suppress ---
+    # --- Step 2b: Skin type -> functional signal dim boost/suppress ---
     if skin_type in SKIN_TYPE_SIGNAL_PREFS and _signal_dim:
         boost_sigs, suppress_sigs = SKIN_TYPE_SIGNAL_PREFS[skin_type]
-        SIGNAL_BOOST = 0.25
-        SIGNAL_SUPPRESS = 0.5
         for sig in boost_sigs:
             if sig in _signal_dim:
-                base_vector[_signal_dim[sig]] += SIGNAL_BOOST
+                base_vector[_signal_dim[sig]] += _SIGNAL_BOOST
         for sig in suppress_sigs:
             if sig in _signal_dim:
-                base_vector[_signal_dim[sig]] *= SIGNAL_SUPPRESS
+                base_vector[_signal_dim[sig]] *= _SIGNAL_SUPPRESS
 
-    # --- Step 3: preferred_ingredients -> TF-IDF dim boost ---
+    # --- Step 2c: Skin concerns -> signal dim boost/suppress ---
+    concerns = explicit_prefs.get("concerns") or []
+    if concerns and _signal_dim:
+        for concern in concerns:
+            if concern in CONCERN_SIGNAL_PREFS:
+                boost_sigs, suppress_sigs = CONCERN_SIGNAL_PREFS[concern]
+                for sig in boost_sigs:
+                    if sig in _signal_dim:
+                        base_vector[_signal_dim[sig]] += _CONCERN_BOOST
+                for sig in suppress_sigs:
+                    if sig in _signal_dim:
+                        base_vector[_signal_dim[sig]] *= _CONCERN_SUPPRESS
+
+    # --- Step 2d: Sensitivity level -> irritation_risk suppression ---
+    sensitivity = (explicit_prefs.get("sensitivity_level") or "not_sure").lower()
+    if _signal_dim and "irritation_risk" in _signal_dim:
+        factor = SENSITIVITY_SUPPRESS.get(sensitivity, 0.7)
+        base_vector[_signal_dim["irritation_risk"]] *= factor
+
+    # --- Step 3: Preferred ingredients -> TF-IDF dim boost ---
     preferred_ingredients = explicit_prefs.get("preferred_ingredients") or []
     if preferred_ingredients and TFIDF_PATH.exists():
         _load_tfidf_vocab()
-        INGREDIENT_BOOST = 0.15
         for ing in preferred_ingredients:
             token = ing.lower().strip()
             if token in _tfidf_vocab:
-                base_vector[_tfidf_vocab[token]] += INGREDIENT_BOOST
+                base_vector[_tfidf_vocab[token]] += _INGREDIENT_BOOST
 
-    # --- Step 4: preferred_categories -> category dim boost ---
+    # --- Step 4: Preferred categories -> category dim boost ---
     preferred_categories = explicit_prefs.get("preferred_categories") or []
-    CAT_BOOST = 0.5
     for cat in preferred_categories:
         if cat in _cat_dim:
-            base_vector[_cat_dim[cat]] += CAT_BOOST
+            base_vector[_cat_dim[cat]] += _CATEGORY_BOOST
 
     # --- Step 5: budget -> price dim (cold start only) ---
     budget = explicit_prefs.get("budget")

--- a/skincarelib/models/user_profile.py
+++ b/skincarelib/models/user_profile.py
@@ -203,6 +203,8 @@ def build_user_vector(
     else:
         base_vector = np.zeros(TOTAL_DIMS, dtype=np.float32)
 
+    n_dims = len(base_vector)  # guard: schema dims may exceed test fixture sizes
+
     # --- Step 2a: Skin type -> ingredient group dim boost/suppress ---
     skin_type = (explicit_prefs.get("skin_type") or "").lower().strip()
     if skin_type in SKIN_TYPE_PREFS:
@@ -215,11 +217,13 @@ def build_user_vector(
             if grp not in _group_dim:
                 continue
             dim = _group_dim[grp]
+            if dim >= n_dims:
+                continue
             group_offset = dim - GROUPS_START
             delta = float(catalog_group_mean[group_offset]) * _GROUP_BOOST_FACTOR
             base_vector[dim] += delta
         for grp in suppress_groups:
-            if grp not in _group_dim:
+            if grp not in _group_dim or _group_dim[grp] >= n_dims:
                 continue
             base_vector[_group_dim[grp]] *= _GROUP_SUPPRESS_FACTOR
 
@@ -227,10 +231,10 @@ def build_user_vector(
     if skin_type in SKIN_TYPE_SIGNAL_PREFS and _signal_dim:
         boost_sigs, suppress_sigs = SKIN_TYPE_SIGNAL_PREFS[skin_type]
         for sig in boost_sigs:
-            if sig in _signal_dim:
+            if sig in _signal_dim and _signal_dim[sig] < n_dims:
                 base_vector[_signal_dim[sig]] += _SIGNAL_BOOST
         for sig in suppress_sigs:
-            if sig in _signal_dim:
+            if sig in _signal_dim and _signal_dim[sig] < n_dims:
                 base_vector[_signal_dim[sig]] *= _SIGNAL_SUPPRESS
 
     # --- Step 2c: Skin concerns -> signal dim boost/suppress ---
@@ -240,17 +244,19 @@ def build_user_vector(
             if concern in CONCERN_SIGNAL_PREFS:
                 boost_sigs, suppress_sigs = CONCERN_SIGNAL_PREFS[concern]
                 for sig in boost_sigs:
-                    if sig in _signal_dim:
+                    if sig in _signal_dim and _signal_dim[sig] < n_dims:
                         base_vector[_signal_dim[sig]] += _CONCERN_BOOST
                 for sig in suppress_sigs:
-                    if sig in _signal_dim:
+                    if sig in _signal_dim and _signal_dim[sig] < n_dims:
                         base_vector[_signal_dim[sig]] *= _CONCERN_SUPPRESS
 
     # --- Step 2d: Sensitivity level -> irritation_risk suppression ---
     sensitivity = (explicit_prefs.get("sensitivity_level") or "not_sure").lower()
     if _signal_dim and "irritation_risk" in _signal_dim:
-        factor = SENSITIVITY_SUPPRESS.get(sensitivity, 0.7)
-        base_vector[_signal_dim["irritation_risk"]] *= factor
+        ir_dim = _signal_dim["irritation_risk"]
+        if ir_dim < n_dims:
+            factor = SENSITIVITY_SUPPRESS.get(sensitivity, 0.7)
+            base_vector[ir_dim] *= factor
 
     # --- Step 3: Preferred ingredients -> TF-IDF dim boost ---
     preferred_ingredients = explicit_prefs.get("preferred_ingredients") or []
@@ -258,19 +264,24 @@ def build_user_vector(
         _load_tfidf_vocab()
         for ing in preferred_ingredients:
             token = ing.lower().strip()
-            if token in _tfidf_vocab:
+            if token in _tfidf_vocab and _tfidf_vocab[token] < n_dims:
                 base_vector[_tfidf_vocab[token]] += _INGREDIENT_BOOST
 
     # --- Step 4: Preferred categories -> category dim boost ---
     preferred_categories = explicit_prefs.get("preferred_categories") or []
     for cat in preferred_categories:
-        if cat in _cat_dim:
+        if cat in _cat_dim and _cat_dim[cat] < n_dims:
             base_vector[_cat_dim[cat]] += _CATEGORY_BOOST
 
     # --- Step 5: budget -> price dim (cold start only) ---
     budget = explicit_prefs.get("budget")
     price_dim = PRICE_DIM
-    if budget is not None and not valid_ids:
+    if (
+        budget is not None
+        and not valid_ids
+        and price_dim is not None
+        and price_dim < n_dims
+    ):
         budget = float(budget)
         if budget <= 20:
             base_vector[price_dim] = 0.15

--- a/skincarelib/models/vectorizer.py
+++ b/skincarelib/models/vectorizer.py
@@ -230,7 +230,6 @@ def build_faiss_index(vectors: np.ndarray):
     index.hnsw.efConstruction = 300
     index.hnsw.efSearch = 256
 
-
     index.add(vectors)
     print(f"FAISS HNSW index built: {index.ntotal} vectors, dim={dim}")
     return index
@@ -250,7 +249,6 @@ def save_outputs(X, df, schema, tfidf_vec):
         json.dump(schema, f, indent=2)
 
     joblib.dump(tfidf_vec, ARTIFACT_DIR / "tfidf.joblib")
-
 
     # FAISS HNSW ANN index — used in dupe_finder for approximate candidate retrieval
     if faiss is not None:

--- a/tests/test_temporal_decay.py
+++ b/tests/test_temporal_decay.py
@@ -1,0 +1,173 @@
+"""
+Tests for temporal decay in compute_user_vector_with_decay.
+
+Key properties verified:
+- Recent interactions outweigh older ones
+- All-same-age interactions match compute_user_vector output
+- Fallback to compute_user_vector when no timestamps present
+- lambda_decay=0 (no decay) matches simple mean behaviour
+- Irritation signal is stronger than dislike (Rocchio -2.0 vs -1.0)
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import numpy as np
+
+from skincarelib.ml_system.feedback_update import (
+    UserState,
+    compute_user_vector,
+    compute_user_vector_with_decay,
+)
+
+DIM = 8
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+def _days_ago(n: int) -> datetime:
+    return _now() - timedelta(days=n)
+
+
+def test_recent_like_outweighs_old_like():
+    """A like from yesterday should pull the vector more than one from 90 days ago."""
+    vec_old = np.zeros(DIM, dtype=np.float32)
+    vec_old[0] = 1.0  # old like points to dim 0
+
+    vec_recent = np.zeros(DIM, dtype=np.float32)
+    vec_recent[1] = 1.0  # recent like points to dim 1
+
+    user = UserState(dim=DIM)
+    user.add_liked(vec_old, [], timestamp=_days_ago(90))
+    user.add_liked(vec_recent, [], timestamp=_days_ago(1))
+
+    result = compute_user_vector_with_decay(user, lambda_decay=0.01)
+
+    # dim 1 (recent) should contribute more than dim 0 (old)
+    assert result[1] > result[0]
+
+
+def test_equal_timestamps_matches_uniform_average():
+    """When all interactions happened at the same time, decay weights are equal
+    and the result should match compute_user_vector."""
+    vec_a = np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    vec_b = np.array([0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+
+    ts = _days_ago(10)
+    user_decay = UserState(dim=DIM)
+    user_decay.add_liked(vec_a, [], timestamp=ts)
+    user_decay.add_liked(vec_b, [], timestamp=ts)
+
+    user_plain = UserState(dim=DIM)
+    user_plain.add_liked(vec_a, [])
+    user_plain.add_liked(vec_b, [])
+
+    result_decay = compute_user_vector_with_decay(user_decay, lambda_decay=0.01)
+    result_plain = compute_user_vector(user_plain)
+
+    np.testing.assert_allclose(result_decay, result_plain, atol=1e-4)
+
+
+def test_fallback_when_no_timestamps():
+    """UserState with no timestamps falls back to compute_user_vector."""
+    vec = np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+
+    user = UserState(dim=DIM)
+    # Manually append without timestamp to simulate legacy state
+    user.liked_vectors.append(vec)
+    user.liked_count += 1
+    user.interactions += 1
+    # liked_timestamps stays empty
+
+    result_decay = compute_user_vector_with_decay(user, lambda_decay=0.01)
+    result_plain = compute_user_vector(user)
+
+    np.testing.assert_allclose(result_decay, result_plain, atol=1e-6)
+
+
+def test_zero_lambda_matches_plain_vector():
+    """lambda_decay=0 means no decay — all weights = 1.0 — should match compute_user_vector."""
+    vec_a = np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    vec_b = np.array([0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+
+    user_decay = UserState(dim=DIM)
+    user_decay.add_liked(vec_a, [], timestamp=_days_ago(1))
+    user_decay.add_liked(vec_b, [], timestamp=_days_ago(90))
+
+    user_plain = UserState(dim=DIM)
+    user_plain.add_liked(vec_a, [])
+    user_plain.add_liked(vec_b, [])
+
+    result_decay = compute_user_vector_with_decay(user_decay, lambda_decay=0.0)
+    result_plain = compute_user_vector(user_plain)
+
+    np.testing.assert_allclose(result_decay, result_plain, atol=1e-4)
+
+
+def test_irritation_suppresses_more_than_dislike():
+    """Irritation (Rocchio -2.0) should suppress output more than dislike (-1.0)."""
+    vec_liked = np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    vec_neg = np.array([0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+    ts = _days_ago(5)
+
+    user_dislike = UserState(dim=DIM)
+    user_dislike.add_liked(vec_liked, [], timestamp=ts)
+    user_dislike.add_disliked(vec_neg, [], timestamp=ts)
+
+    user_irritation = UserState(dim=DIM)
+    user_irritation.add_liked(vec_liked, [], timestamp=ts)
+    user_irritation.add_irritation(vec_neg, [], timestamp=ts)
+
+    result_dislike = compute_user_vector_with_decay(user_dislike)
+    result_irritation = compute_user_vector_with_decay(user_irritation)
+
+    # irritation should suppress dim 1 more → result_irritation[1] < result_dislike[1]
+    assert result_irritation[1] < result_dislike[1]
+
+
+def test_output_is_normalized():
+    """Result should always be a unit vector."""
+    user = UserState(dim=DIM)
+    user.add_liked(np.ones(DIM, dtype=np.float32), [], timestamp=_days_ago(10))
+    user.add_disliked(np.ones(DIM, dtype=np.float32) * 0.5, [], timestamp=_days_ago(5))
+
+    result = compute_user_vector_with_decay(user)
+    assert abs(np.linalg.norm(result) - 1.0) < 1e-5
+
+
+def test_misaligned_vectors_and_timestamps_falls_back():
+    """If vectors and timestamps are out of sync, fall back to compute_user_vector."""
+    vec = np.array([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=np.float32)
+
+    user = UserState(dim=DIM)
+    # Manually create misalignment: 2 vectors but only 1 timestamp
+    user.liked_vectors.append(vec)
+    user.liked_vectors.append(vec)
+    user.liked_timestamps.append(_days_ago(5))  # one short
+    user.liked_count = 2
+    user.interactions = 2
+
+    # Should not crash, and should match plain compute_user_vector
+    result_decay = compute_user_vector_with_decay(user, lambda_decay=0.01)
+    result_plain = compute_user_vector(user)
+    np.testing.assert_allclose(result_decay, result_plain, atol=1e-6)
+
+
+def test_high_lambda_decays_old_interactions_aggressively():
+    """With high lambda, a 60-day-old like should have near-zero influence."""
+    vec_old = np.zeros(DIM, dtype=np.float32)
+    vec_old[0] = 1.0
+
+    vec_recent = np.zeros(DIM, dtype=np.float32)
+    vec_recent[1] = 1.0
+
+    user = UserState(dim=DIM)
+    user.add_liked(vec_old, [], timestamp=_days_ago(60))
+    user.add_liked(vec_recent, [], timestamp=_days_ago(1))
+
+    result = compute_user_vector_with_decay(user, lambda_decay=0.1)  # half-life ~7 days
+
+    # With lambda=0.1, 60-day weight ≈ e^-6 ≈ 0.0025 vs 1-day weight ≈ e^-0.1 ≈ 0.90
+    # dim 1 (recent) should dominate heavily
+    assert result[1] > result[0] * 10


### PR DESCRIPTION
 Cold start fix

  Before: user_state.interactions == 0 → scores = [0.5] * len(candidates). Every cold-start user got identical scores, so ranking
   was just whatever order the products dict iterated in. Same page for everyone.

  After — two bugs fixed:

  1. Flat scoring replaced with build_user_vector(liked_product_ids=[], explicit_prefs=...) using the full onboarding profile.
  This creates a real preference vector from skin type + concerns + sensitivity + budget + categories — no interactions needed.
  2. Onboarding fields were being silently dropped. _profile_to_explicit_prefs() only forwarded skin_type, budget,
  preferred_categories, banned_ingredients. The concerns list (acne, redness, etc.) and sensitivity_level were never passed to
  build_user_vector. Two users with the same skin type but different concerns (acne vs redness) got identical cold-start pages.
  Fixed by wiring all fields through.

  The cold-start user vector gets built in build_user_vector like this:

  skin_type → boost/suppress ingredient group dims (step 2a)
            → boost/suppress signal dims (step 2b)
  concerns  → per-concern signal boost/suppress (step 2c)
  sensitivity → scale down irritation_risk dim (step 2d)
  budget    → set price dim (step 5, cold start only)

  ---
  Popularity bias fix — cluster-sampled candidate pool

  The problem: The top-200 candidates by cosine similarity almost always come from the same ~500 products — high-norm vectors
  that score well against nearly any user vector. Two very different users might get the same candidate pool, just ranked
  differently.

  The fix (build_diverse_candidate_pool):

  1. Score all 20 cluster centroids against the user vector  ← O(20), trivial
  2. Take the 8 closest clusters
  3. Allocate the 200 pool slots proportionally to centroid similarity
     (closer cluster gets more slots, but every cluster gets at least 1)
  4. Within each cluster, pick best products by cosine similarity
  5. Pass this pool to MMR for final reranking

  The experiment showed this achieves zero inter-user Jaccard overlap (no two users share any recommended product) vs 0.0053 for
  straight cosine. Catalog coverage didn't improve — that's structural — but user differentiation is better at no cost to
  relevance.

  This runs at startup in app.py: _fit_cold_start_kmeans() fits a MiniBatchKMeans on all product vectors once, builds the
  cluster_to_ids map, and stores both. At request time, build_diverse_candidate_pool uses the pre-fit model — no re-fitting per
  request.

  ---
  CF — what we built and why it doesn't help yet

  What we built (collab_filter.py — ItemBasedCF):

  Fit:   for each user's liked products, count co-occurrences with every
         other product that same user liked → normalise by row sum
         → item-item association table

  Score: given a user's seed items, sum association scores toward each
         candidate → rank by that sum

  No content features at all — purely "users who liked A also liked B."

  Why it doesn't help: The CF model was fit on 9,540 training interactions covering only 4,655 of 50,305 products (9% catalog
  coverage). Most test-liked items were never co-interacted with any training item, so their CF score is 0. Item-based CF needs
  many users to have liked the same items before it builds useful associations. With real production data (thousands of users,
  hundreds of interactions each), it becomes viable. Right now the content model dominates any hybrid combination because the CF
  signal is essentially noise.

  CF is not in the serving path. It exists in collab_filter.py and eval_cf.py only. The API (app.py) does not call it.